### PR TITLE
Pin working jsdom dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies"    : {
     "fabric"      : "git://github.com/iFixit/fabric.js.git"
-   ,"jsdom"       : "0.5.x"
+   ,"jsdom"       : "0.5.6"
    ,"xmldom"      : ">= 0.1.13"
    ,"optimist"    : "git://github.com/substack/node-optimist.git"
    ,"gm"          : ">= 1.8.1"


### PR DESCRIPTION
It turns out that a change[0](https://github.com/tmpvar/jsdom/commit/6ed9c6bc0d882c034e8710dc23e6d01e35f52255) between jsdom 0.5.6 and 0.5.7 just broke
node-canvas.  Entirely.  And the maintainer didn't release another 0.5.x
to fix it. >_<

This took a long time to track down, so let's save everyone (including
ourselves) the trouble.  Pin a more specific version, since we now have
no confidence in jsdom's version numbers.
