### PR TITLE
Make shape maximum sizes larger

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -42,8 +42,8 @@ function ImageMarkupBuilder(canvas) {
       rectangle: 128
    };
    var maximumSizeRatio = {
-      circle: 0.3, // Max size of radius
-      rectangle: 0.8 // Max size of side
+      circle: 0.45, // Max size of radius
+      rectangle: 1.3 // Max size of side
    };
    var initialSize = {
       circle: 12,


### PR DESCRIPTION
Based on customer requests, this is an improvement that changes the maximum markup shape sizes to be about as large as the image.

QA steps:
1. `git co master && git pull`
2. `cd 3P/node-markup`
3. `git co hotfix-make-shape-max-sizes-larger`
4. Go to an image markup module
5. Add a circle or rectangle
6. Test maximum sizes
