### PR TITLE
Fix getMarkupString calculation on rectangles

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -741,7 +741,7 @@ function ImageMarkupBuilder(canvas) {
                       / resizeRatio) - (outline.width - rectangle.width) / 2
                       + imageOffset.x,
                      'y': Math.round((group.top - rectangle.height / 2)
-                      / resizeRatio) - (outline.width - rectangle.width) / 2
+                      / resizeRatio) - (outline.height - rectangle.height) / 2
                       + imageOffset.y
                   };
                   var size = {


### PR DESCRIPTION
getMarkupString was improperly using inner rectangle width to offset the
top-left corner of the rectangle, which was offsetting the new value by
the difference between group width and rectangle width every time. Use
the proper shape width to calculate that value to make the calculations
consistent.
