### PR TITLE
Positioning: Fix shifting markup bug

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -357,14 +357,13 @@ function ImageMarkupBuilder(canvas) {
       }
 
       //Fabric調整
-      rect['top'] = rect['top'] + rect['height'] / 2
-       + rect['strokeWidth'] / 2;
+      rect['top'] = rect['top'] + rect['height'] / 2;
       rect['top'] *= resizeRatio;
-      rect['left'] = rect['left'] + rect['width'] / 2
-       + rect['strokeWidth'] / 2;
+      rect['left'] = rect['left'] + rect['width'] / 2;
       rect['left'] *= resizeRatio;
       rect['width'] *= resizeRatio;
       rect['height'] *= resizeRatio;
+
 
       rect.shapeFunction = "shape";
 


### PR DESCRIPTION
Previously all rectangles would shift slightly from where they were
placed to be when drawn (and thus the numbers would change slightly).

The main colored rectangle was trying to take into account the width of
the thin white outline in it's positioning and it didn't need to.
