### PR TITLE
Reduce whitestroke size on markup

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -55,7 +55,7 @@ function ImageMarkupBuilder(fabricCanvas) {
 
    var markupObjects = new Array();
 
-   var whiteStroke = isNode ? 2 : 1;
+   var whiteStroke = isNode ? 1 : 0.5;
    var strokeWidth = null;
    var crop = null;
 


### PR DESCRIPTION
As per tech writer request, smaller white outlines/inlines look better.
Shrink them.

Before:
![indznwpdgaphytvd](https://f.cloud.github.com/assets/698869/676213/2865881c-d901-11e2-8d7f-2b08f3173c73.jpg)

After:
![4ekqvrcq6cny1tfp](https://f.cloud.github.com/assets/698869/676223/3d125e5c-d901-11e2-9c1b-3d5dac0bb01e.jpg)
