### PR TITLE
package.json: Remove spaces in dependency versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "dependencies"    : {
     "fabric"      : "git://github.com/iFixit/fabric.js.git"
    ,"jsdom"       : "0.5.6"
-   ,"xmldom"      : ">= 0.1.13"
+   ,"xmldom"      : ">=0.1.13"
    ,"optimist"    : "git://github.com/substack/node-optimist.git"
-   ,"gm"          : ">= 1.8.1"
+   ,"gm"          : ">=1.8.1"
   },
   "version"         : "0.0.2"
 }


### PR DESCRIPTION
Since multiple restrictions can be placed upon the version of a dependency, there shouldn't be a space in '>= 0.1.13'.

See: http://package-json-validator.com/