### PR TITLE
Tests: fail with exit code.

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -93,6 +93,7 @@ def runNode(sourceFilename, destinationFilename, markupFilename):
 
    return ret == 0;
 
+errors = 0
 for filename in os.listdir(testDirectory):
    if filename.endswith(".markup"):
       markupFilename = testDirectory + filename;
@@ -109,4 +110,6 @@ for filename in os.listdir(testDirectory):
 
       except RuntimeError, msg:
          print >> sys.stderr, basename + ':', msg;
+         errors += 1
          continue;
+sys.exit(errors)


### PR DESCRIPTION
When running tests programmatically, it's nice to have test failures
cause a failure exit code from the test runner.  An easy way to do that
is to set the exit code to the number of errors that have occurred.
