### PR TITLE
JPEG output: enable progressive compression

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -248,7 +248,8 @@ function ImageMarkupBuilder(fabricCanvas) {
       fabricCanvas.renderAll();
       var outstream = FS.createWriteStream(innerJSON.destinationFile),
       stream = fabricCanvas.createJPEGStream({
-         quality: 93
+         quality: 93,
+         progressive: true
       });
 
       stream.on('data', function(chunk) {


### PR DESCRIPTION
I made a corresponding update in canvas that has now been merged:
https://github.com/LearnBoost/node-canvas/commit/d72c1bbf022b0c56e242211f25c584c4eb6a4e6b

Progressive JPEGs are smaller (2-7%) and have a lower time-to-first
paint in browsers.
