### PR TITLE
Nudge: move size limits and nudging to mixins

### DIFF
--- a/limit_size.js
+++ b/limit_size.js
@@ -1,0 +1,40 @@
+module.exports = {
+   _withSizeLimitations: function(callback) {
+      this._limitSize = true;
+      callback.apply(this);
+      this._limitSize = false;
+   },
+
+   _set: function(key, value) {
+      var newValue = value;
+      if (key === 'scaleX') {
+         var newWidth = this.width * value;
+         newValue = this._limitDimension(newWidth) / this.width;
+      } else if (key === 'scaleY') {
+         var newHeight = this.height * value;
+         newValue = this._limitDimension(newHeight) / this.height;
+      }
+
+      return this.callSuper('_set', key, newValue);
+   },
+
+   _limitDimension: function(x) {
+      // The _isMoving condition seems backwards. It's because fabric has it
+      // on during scaling *and* moving but fires this a few times with
+      // isMoving off during an actual move.
+      if (!this._limitSize && !this.isMoving) return x;
+
+      if (this.minSize !== false) {
+         // Sometimes we have to limit negative values too (see: scaleX)
+         if (Math.abs(x) < this.minSize)
+            return x >= 0 ? this.minSize : -this.minSize;
+      }
+
+      if (this.maxSize !== false) {
+         if (Math.abs(x) > this.maxSize)
+            return x >= 0 ? this.maxSize : -this.maxSize;
+      }
+      return x;
+   }
+};
+

--- a/nudge.js
+++ b/nudge.js
@@ -1,0 +1,76 @@
+module.exports = {
+   /**
+    * Grows the given shape in the given direction by the given number of
+    * pixels relative to its current position.
+    *
+    * @param directionMap A key-value object with the keys {up, down, left,
+    *  right} each with a true/false value.
+    * @param distance The number of pixels to move the shape.
+    */
+   grow: function nudge(directionMap, distance) {
+      var shape = this;
+      if (directionMap.left) {
+         shape.left -= distance/2;
+         shape.incrementSize(distance, 'X');
+      }
+      if (directionMap.right) {
+         shape.left += distance/2;
+         shape.incrementSize(distance, 'X');
+      }
+      if (directionMap.up) {
+         shape.top -= distance/2;
+         shape.incrementSize(distance, 'Y');
+      }
+      if (directionMap.down) {
+         shape.top += distance/2;
+         shape.incrementSize(distance, 'Y');
+      }
+      shape.setCoords();
+   },
+
+   /**
+    * Moves the given shape in the given direction by the given number of
+    * pixels relative to its current position.
+    *
+    * @param directionMap A key-value object with the keys {up, down, left,
+    *  right} each with a true/false value.
+    * @param distance The number of pixels to move the shape.
+    */
+   nudge: function nudge(directionMap, distance) {
+      var shape = this;
+
+      if (directionMap.left) {
+         shape.left -= distance;
+         shape.setCoords();
+         if (isOffScreen(shape)) {
+            shape.left += distance;
+         }
+      }
+      if (directionMap.right) {
+         shape.left += distance;
+         shape.setCoords();
+         if (isOffScreen(shape)) {
+            shape.left -= distance;
+         }
+      }
+      if (directionMap.up) {
+         shape.top -= distance;
+         shape.setCoords();
+         if (isOffScreen(shape)) {
+            shape.top += distance;
+         }
+      }
+      if (directionMap.down) {
+         shape.top += distance;
+         shape.setCoords();
+         if (isOffScreen(shape)) {
+            shape.top -= distance;
+         }
+      }
+      shape.setCoords();
+   }
+};
+
+function isOffScreen(object) {
+   return object.canvas.isOffScreen(object);
+}

--- a/shape_circle.js
+++ b/shape_circle.js
@@ -39,7 +39,6 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
    },
 
    render: function(ctx) {
-      this._limitSize();
       this.callSuper('render', ctx);
    },
 
@@ -51,8 +50,10 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
       var xdiff = x2 - this.left;
       var ydiff = y2 - this.top;
       var radius = Math.sqrt(xdiff * xdiff + ydiff * ydiff);
-      this.scaleToWidth(radius * 2);
-      this.setCoords();
+      this._withSizeLimitations(function() {
+         this.scaleToWidth(this._limitDimension(radius * 2));
+         this.setCoords();
+      });
    },
 
    /**
@@ -60,20 +61,6 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
     */
    incrementSize: function(increment) {
       this.scaleToWidth(this.currentWidth + increment);
-      this.setCoords();
-   },
-
-   /**
-    * Enforce the min / max sizes if set.
-    */
-   _limitSize: function() {
-      var newRadius = this.getRadiusX();
-
-      if (this.minSize !== false && newRadius < this.minSize) {
-         this.scaleX = this.scaleY = this.minSize / this.radius;
-      } else if (this.maxSize !== false && newRadius > this.maxSize) {
-         this.scaleX = this.scaleY = this.maxSize / this.radius;
-      }
       this.setCoords();
    },
 
@@ -94,5 +81,8 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
 Circle.fromObject = function(object) {
    return new Circle(object);
 };
+
+extend(Circle.prototype, require('./limit_size'));
+extend(Circle.prototype, require('./nudge'));
 
 module.exports.klass = Circle;


### PR DESCRIPTION
A bunch of logic has been moved to re-usable mixins.
There was a decent amount of common code.

Changes in functionality:

* New shape.grow() function
* shape.grow() and .incrementSize() both allow bypassing the size
  limits while scaling via the mouse doesn't.