### PR TITLE
Shapes: add support for Lines

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -505,6 +505,13 @@ function ImageMarkupBuilder(fabricCanvas) {
       data.from.x += imageOffset.x;
       data.from.y += imageOffset.y;
 
+      if (data.to) {
+         data.to.x /= resizeRatio;
+         data.to.y /= resizeRatio;
+         data.to.x += imageOffset.x;
+         data.to.y += imageOffset.y;
+      }
+
       if (!data.color) {
          data.color = "red";
       }

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -219,6 +219,9 @@ function ImageMarkupBuilder(fabricCanvas) {
                      case 'circle':
                         drawCircle(shape);
                         break;
+                     case 'line':
+                        drawLine(shape);
+                        break;
                      default:
                         console.error('Unsupported Shape: ' + shapeName);
                   }
@@ -322,10 +325,6 @@ function ImageMarkupBuilder(fabricCanvas) {
       shape.stroke = getStrokeWidth(finalWidth);
 
       var line = {
-         left: shape.from.x - imageOffset.x,
-         top: shape.from.y - imageOffset.y,
-         width: shape.to.x - shape.from.x,
-         height: shape.to.y - shape.from.y,
          minSize: minimumSize.line,
          maxSize: maximumSize.line,
          borderWidth: shape.stroke,
@@ -333,16 +332,18 @@ function ImageMarkupBuilder(fabricCanvas) {
          color: shape.color
       }
 
-      line.top *= resizeRatio;
-      line.left *= resizeRatio;
-      line.width *= resizeRatio;
-      line.height *= resizeRatio;
+      var points = [
+         shape.from.x * resizeRatio,
+         shape.from.y * resizeRatio,
+         shape.to.x * resizeRatio,
+         shape.to.y * resizeRatio
+      ];
 
       if (isNode) {
          line.minSize = line.maxSize = false;
       }
 
-      var fabricLine = new Shapes.Line(line);
+      var fabricLine = new Shapes.Line(points, line);
       fabricLine.color = shape.color;
 
       markupObjects.push(fabricLine);
@@ -730,6 +731,9 @@ function ImageMarkupBuilder(fabricCanvas) {
 
                   markupString += "rectangle," + from.x + "x" + from.y + ","
                    + size.width + "x" + size.height + "," + color +  ";";
+                  break;
+               case 'line':
+                  markupString += object.toMarkup(resizeRatio);
                   break;
                default:
                   console.error("Unexpected object name: " + object.shapeName);

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -1,12 +1,10 @@
 var isNode = typeof window == 'undefined';
 
-
 /**
  * Expects a Fabric.js Canvas
  */
 function ImageMarkupBuilder(fabricCanvas) {
    var Fabric = require('fabric').fabric || fabric;
-   var FS = require('fs');
 
    var Shapes = {
       Rectangle:  require("./shape_rectangle").klass,
@@ -162,7 +160,7 @@ function ImageMarkupBuilder(fabricCanvas) {
             whiteStroke = 1;
          }
          if (isNode) {
-            FS.readFile(innerJSON.sourceFile, function (err, blob) {
+            require('fs').readFile(innerJSON.sourceFile, function (err, blob) {
                if (err) throw err;
 
                var dimensions = innerJSON.dimensions;
@@ -250,7 +248,7 @@ function ImageMarkupBuilder(fabricCanvas) {
     */
    function writeCanvas(callback) {
       fabricCanvas.renderAll();
-      var outstream = FS.createWriteStream(innerJSON.destinationFile),
+      var outstream = require('fs').createWriteStream(innerJSON.destinationFile),
       stream = fabricCanvas.createJPEGStream({
          quality: 93,
          progressive: true

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -44,7 +44,7 @@ function ImageMarkupBuilder(fabricCanvas) {
    var maximumSize = {
       circle: 128,
       rectangle: 128,
-      line: 128
+      line: 300
    };
    var maximumSizeRatio = {
       circle: 0.6, // Max size of radius

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -39,12 +39,12 @@ function ImageMarkupBuilder(fabricCanvas) {
    var minimumSize = {
       circle: 8,
       rectangle: 16,
-      line: 16
+      line: 20
    };
    var maximumSize = {
       circle: 128,
       rectangle: 128,
-      line: 300
+      line: 400
    };
    var maximumSizeRatio = {
       circle: 0.6, // Max size of radius

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -10,7 +10,8 @@ function ImageMarkupBuilder(fabricCanvas) {
 
    var Shapes = {
       Rectangle:  require("./shape_rectangle").klass,
-      Circle:     require("./shape_circle").klass
+      Circle:     require("./shape_circle").klass,
+      Line:       require("./shape_line").klass
    };
 
    var colorValues = {
@@ -39,19 +40,17 @@ function ImageMarkupBuilder(fabricCanvas) {
    var finalWidth = 0;
    var minimumSize = {
       circle: 8,
-      rectangle: 16
+      rectangle: 16,
+      line: 16
    };
    var maximumSize = {
       circle: 128,
-      rectangle: 128
+      rectangle: 128,
+      line: 128
    };
    var maximumSizeRatio = {
       circle: 0.6, // Max size of radius
       rectangle: 0.8 // Max size of side
-   };
-   var initialSize = {
-      circle: 12,
-      rectangle: 24
    };
 
    var markupObjects = new Array();
@@ -64,6 +63,7 @@ function ImageMarkupBuilder(fabricCanvas) {
     * Array of delegate functions to draw a proper shape.
     */
    var addShapeDelegate = {
+      line: drawLine,
       circle: drawCircle,
       rectangle: function (data) {
          // Because fabric considers top/left as the center of the rectangle.
@@ -316,6 +316,44 @@ function ImageMarkupBuilder(fabricCanvas) {
       }
 
       return fabricRect;
+   }
+
+   function drawLine(shape) {
+      shape.stroke = getStrokeWidth(finalWidth);
+
+      var line = {
+         left: shape.from.x - imageOffset.x,
+         top: shape.from.y - imageOffset.y,
+         width: shape.to.x - shape.from.x,
+         height: shape.to.y - shape.from.y,
+         minSize: minimumSize.line,
+         maxSize: maximumSize.line,
+         borderWidth: shape.stroke,
+         stroke: colorValues[shape.color],
+         color: shape.color
+      }
+
+      line.top *= resizeRatio;
+      line.left *= resizeRatio;
+      line.width *= resizeRatio;
+      line.height *= resizeRatio;
+
+      if (isNode) {
+         line.minSize = line.maxSize = false;
+      }
+
+      var fabricLine = new Shapes.Line(line);
+      fabricLine.color = shape.color;
+
+      markupObjects.push(fabricLine);
+      fabricCanvas.add(fabricLine);
+
+      if (!isNode) {
+         // Set this as the active object
+         fabricCanvas.setActiveObject(fabricLine);
+      }
+
+      return fabricLine;
    }
 
    function drawCircle(shape) {

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -167,6 +167,26 @@ function convertMarkupToJSON(callback, markup, infile, outfile) {
 
             json['instructions']['draw'].push({'rectangle': rectangle});
             break;
+         case 'line':
+            if (!json['instructions']['draw']) json['instructions']['draw'] = new Array();
+
+            var p1 = args[1].split("x");
+            var p2 = args[2].split("x");
+
+            var line = {
+               from: {
+                  x: Int(p1[0]),
+                  y: Int(p1[1])
+               },
+               to: {
+                  x: Int(p2[0]),
+                  y: Int(p2[1])
+               },
+               color: args[3]
+            };
+
+            json['instructions']['draw'].push({line: line});
+            break;
          default:
       }
       }

--- a/drag_to_create.js
+++ b/drag_to_create.js
@@ -25,7 +25,9 @@ function setupMarkerCreation(markupBuilder) {
          }
       } else {
          
-         currentShape.sizeByMousePos(x(mouseDownEvent), y(mouseDownEvent), x(event.e), y(event.e));
+         currentShape._withSizeLimitations(function() {
+            currentShape.sizeByMousePos(x(mouseDownEvent), y(mouseDownEvent), x(event.e), y(event.e));
+         });
          canvas.renderAll();
       }
    }, 'mouse:up': function() {

--- a/drag_to_create.js
+++ b/drag_to_create.js
@@ -74,12 +74,11 @@ function setupMarkerCreation(markupBuilder) {
          };
       },
       'line': function(mouseStart, mouseCurrent) {
-         var x1 = x(mouseStart), y1 = y(mouseStart);
          return {
             type: 'line',
             from: {
-               x: x1,
-               y: y1
+               x: x(mouseStart),
+               y: y(mouseStart)
             },
             to: {
                x: x(mouseCurrent),

--- a/drag_to_create.js
+++ b/drag_to_create.js
@@ -8,7 +8,7 @@ function setupMarkerCreation(markupBuilder) {
        mouseDownEvent,
        color,
        currentShape,
-       shapeMode = Enum(['circle', 'rectangle']);
+       shapeMode = Enum(['circle', 'rectangle', 'line']);
 
    canvas.on({
    'mouse:down': function(event) {
@@ -72,7 +72,21 @@ function setupMarkerCreation(markupBuilder) {
                height: y(mouseCurrent) - y1
             }
          };
-      }
+      },
+      'line': function(mouseStart, mouseCurrent) {
+         var x1 = x(mouseStart), y1 = y(mouseStart);
+         return {
+            type: 'line',
+            from: {
+               x: x1,
+               y: y1
+            },
+            to: {
+               x: x(mouseCurrent),
+               y: y(mouseCurrent)
+            }
+         };
+      },
    }
 
    markupBuilder.shapeCreator = {

--- a/highlighted_stroke.mixin.js
+++ b/highlighted_stroke.mixin.js
@@ -1,0 +1,22 @@
+module.exports = {
+   borderWidth: 4,
+   strokeWidth: 0,
+   outlineWidth: 1,
+   outlineStyle: '#FFF',
+
+   /**
+    * Provide a custom stroke function that draws a fat white line THEN a
+    * narrower colored line on top.
+    */
+   _stroke: function(ctx) {
+      var myScale = this.scaleX;
+      function scale(x) { return (x / myScale); }
+      ctx.lineWidth = scale(this.borderWidth + this.outlineWidth);
+      ctx.strokeStyle = this.outlineStyle;
+      ctx.stroke();
+
+      ctx.lineWidth = scale(this.borderWidth - this.outlineWidth);
+      ctx.strokeStyle = this.stroke;
+      ctx.stroke();
+   }
+};

--- a/highlighted_stroke.mixin.js
+++ b/highlighted_stroke.mixin.js
@@ -1,7 +1,8 @@
 module.exports = {
    borderWidth: 4,
    strokeWidth: 0,
-   outlineWidth: 1,
+   // in percentage of borderWidth
+   outlineWidth: 0.25,
    outlineStyle: '#FFF',
 
    /**
@@ -10,12 +11,13 @@ module.exports = {
     */
    _stroke: function(ctx) {
       var myScale = this.scaleX;
+      var outline = Math.floor(this.borderWidth * this.outlineWidth);
       function scale(x) { return (x / myScale); }
-      ctx.lineWidth = scale(this.borderWidth + this.outlineWidth);
+      ctx.lineWidth = scale(this.borderWidth + outline);
       ctx.strokeStyle = this.outlineStyle;
       ctx.stroke();
 
-      ctx.lineWidth = scale(this.borderWidth - this.outlineWidth);
+      ctx.lineWidth = scale(this.borderWidth - outline);
       ctx.strokeStyle = this.stroke;
       ctx.stroke();
    }

--- a/limit_size.js
+++ b/limit_size.js
@@ -1,0 +1,40 @@
+module.exports = {
+   _withSizeLimitations: function(callback) {
+      this._limitSize = true;
+      callback.apply(this);
+      this._limitSize = false;
+   },
+
+   _set: function(key, value) {
+      var newValue = value;
+      if (key === 'scaleX') {
+         var newWidth = this.width * value;
+         newValue = this._limitDimension(newWidth) / this.width;
+      } else if (key === 'scaleY') {
+         var newHeight = this.height * value;
+         newValue = this._limitDimension(newHeight) / this.height;
+      }
+
+      return this.callSuper('_set', key, newValue);
+   },
+
+   _limitDimension: function(x) {
+      // The _isMoving condition seems backwards. It's because fabric has it
+      // on during scaling *and* moving but fires this a few times with
+      // isMoving off during an actual move.
+      if (!this._limitSize && !this.isMoving) return x;
+
+      if (this.minSize !== false) {
+         // Sometimes we have to limit negative values too (see: scaleX)
+         if (Math.abs(x) < this.minSize)
+            return x >= 0 ? this.minSize : -this.minSize;
+      }
+
+      if (this.maxSize !== false) {
+         if (Math.abs(x) > this.maxSize)
+            return x >= 0 ? this.maxSize : -this.maxSize;
+      }
+      return x;
+   }
+};
+

--- a/limit_size.js
+++ b/limit_size.js
@@ -8,21 +8,56 @@ module.exports = {
    _set: function(key, value) {
       var newValue = value;
       if (key === 'scaleX') {
-         var newWidth = this.width * value;
-         newValue = this._limitDimension(newWidth) / this.width;
+         if (this._limitByDiagonal) {
+            if (this._exceedsDiagonalLimit(value, this.scaleY)) {
+               return this;
+            }
+         } else {
+            var newWidth = this.width * value;
+            newValue = this._limitDimension(newWidth) / this.width;
+         }
       } else if (key === 'scaleY') {
-         var newHeight = this.height * value;
-         newValue = this._limitDimension(newHeight) / this.height;
+         if (this._limitByDiagonal) {
+            if (this._exceedsDiagonalLimit(this.scaleX, value)) {
+               return this;
+            }
+         } else {
+            var newHeight = this.height * value;
+            newValue = this._limitDimension(newHeight) / this.height;
+         }
       }
 
       return this.callParent(key, newValue);
    },
 
+   /**
+    * Returns true if the given scale values would cause this shape to exceed
+    * the min/max diagonal size.
+    *
+    * When this returns true, the shape will have already been scaled to the
+    * min / max size and attempted _set() call should not be passed on to the
+    * parent class.
+    */
+   _exceedsDiagonalLimit: function(scaleX, scaleY) {
+      if (!this._shouldLimit()) {
+         return;
+      }
+      var w = this.width * scaleX;
+      var h = this.height * scaleY;
+      var rad = Math.sqrt(w * w + h * h);
+      var clampedRad = this._limitDimension(rad);
+      if (rad !== clampedRad) {
+         var ratio = clampedRad / rad;
+         this.callParent('scaleX', scaleX * ratio);
+         this.callParent('scaleY', scaleY * ratio);
+         return true;
+      }
+   },
+
    _limitDimension: function(x) {
-      // The _isMoving condition seems backwards. It's because fabric has it
-      // on during scaling *and* moving but fires this a few times with
-      // isMoving off during an actual move.
-      if (!this._limitSize && !this.isMoving) return x;
+      if (!this._shouldLimit()) {
+         return x;
+      }
 
       if (this.minSize !== false) {
          // Sometimes we have to limit negative values too (see: scaleX)
@@ -35,6 +70,13 @@ module.exports = {
             return x >= 0 ? this.maxSize : -this.maxSize;
       }
       return x;
+   },
+
+   _shouldLimit: function() {
+      // The _isMoving condition seems backwards. It's because fabric has it
+      // on during scaling *and* moving but fires this a few times with
+      // isMoving off during an actual move.
+      return this._limitSize || this.isMoving;
    }
 };
 

--- a/limit_size.js
+++ b/limit_size.js
@@ -15,7 +15,7 @@ module.exports = {
          newValue = this._limitDimension(newHeight) / this.height;
       }
 
-      return this.callSuper('_set', key, newValue);
+      return this.callParent(key, newValue);
    },
 
    _limitDimension: function(x) {

--- a/mixin.js
+++ b/mixin.js
@@ -1,0 +1,23 @@
+module.exports = function(proto, properties) {
+   for (name in properties) {
+      var val = properties[name];
+      if (proto[name] && typeof val == 'function') {
+         inherit(proto, name, val);
+      } else {
+         proto[name] = val;
+      }
+   }
+}
+
+function inherit(proto, name, func) {
+   var parentFunc = proto[name];
+   proto[name] = function() {
+      var old = this.callParent;
+      this.callParent = parentFunc;
+      var ret = func.apply(this, arguments)
+      if (old) {
+         this.callParent = old;
+      }
+      return ret;
+   }
+}

--- a/nudge.js
+++ b/nudge.js
@@ -1,5 +1,30 @@
 module.exports = {
    /**
+    * Increment the size of the rectangle about its center.
+    */
+   incrementSize: function(increment, axis) {
+      var portionW = this.width / (this.width + this.height);
+      if (axis == 'X') {
+         portionW = 1;
+      } else if (axis == 'Y') {
+         portionW = 0;
+      }
+      var deltaX = increment * portionW;
+      var deltaY = increment * (1 - portionW);
+      var newWidth = this.width + deltaX
+      var newHeight = this.height + deltaY
+
+      // Checks to see if the new size will be too big/small.
+      this.width = newWidth;
+      this.height = newHeight;
+      if (this.originX !== 'center') {
+         this.left -= deltaX / 2;
+         this.top -= deltaY / 2;
+      }
+      this.setCoords();
+   },
+
+   /**
     * Grows the given shape in the given direction by the given number of
     * pixels relative to its current position.
     *

--- a/nudge.js
+++ b/nudge.js
@@ -1,0 +1,76 @@
+module.exports = {
+   /**
+    * Grows the given shape in the given direction by the given number of
+    * pixels relative to its current position.
+    *
+    * @param directionMap A key-value object with the keys {up, down, left,
+    *  right} each with a true/false value.
+    * @param distance The number of pixels to move the shape.
+    */
+   grow: function nudge(directionMap, distance) {
+      var shape = this;
+      if (directionMap.left) {
+         shape.left -= distance/2;
+         shape.incrementSize(distance, 'X');
+      }
+      if (directionMap.right) {
+         shape.left += distance/2;
+         shape.incrementSize(distance, 'X');
+      }
+      if (directionMap.up) {
+         shape.top -= distance/2;
+         shape.incrementSize(distance, 'Y');
+      }
+      if (directionMap.down) {
+         shape.top += distance/2;
+         shape.incrementSize(distance, 'Y');
+      }
+      shape.setCoords();
+   },
+
+   /**
+    * Moves the given shape in the given direction by the given number of
+    * pixels relative to its current position.
+    *
+    * @param directionMap A key-value object with the keys {up, down, left,
+    *  right} each with a true/false value.
+    * @param distance The number of pixels to move the shape.
+    */
+   nudge: function nudge(directionMap, distance) {
+      var shape = this;
+
+      if (directionMap.left) {
+         shape.left -= distance;
+         shape.setCoords();
+         if (isOffScreen(shape)) {
+            shape.left += distance;
+         }
+      }
+      if (directionMap.right) {
+         shape.left += distance;
+         shape.setCoords();
+         if (isOffScreen(shape)) {
+            shape.left -= distance;
+         }
+      }
+      if (directionMap.up) {
+         shape.top -= distance;
+         shape.setCoords();
+         if (isOffScreen(shape)) {
+            shape.top += distance;
+         }
+      }
+      if (directionMap.down) {
+         shape.top += distance;
+         shape.setCoords();
+         if (isOffScreen(shape)) {
+            shape.top -= distance;
+         }
+      }
+      shape.setCoords();
+   }
+};
+
+function isOffScreen(object) {
+   return object.canvas.isOffScreen(object);
+}

--- a/shape_circle.js
+++ b/shape_circle.js
@@ -1,5 +1,6 @@
 var Fabric = require('fabric').fabric || fabric;
 var extend = Fabric.util.object.extend;
+var mixin = require('./mixin');
 
 var Circle = Fabric.util.createClass(Fabric.Circle, {
    // Inherited variables with new values.
@@ -56,13 +57,15 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
    }
 });
 
-extend(Circle.prototype, require('./highlighted_stroke.mixin'));
+var proto = Circle.prototype;
+mixin(proto, require('./highlighted_stroke.mixin'));
+mixin(proto, require('./limit_size'));
+mixin(proto, require('./nudge'));
+
 
 Circle.fromObject = function(object) {
    return new Circle(object);
 };
 
-extend(Circle.prototype, require('./limit_size'));
-extend(Circle.prototype, require('./nudge'));
 
 module.exports.klass = Circle;

--- a/shape_circle.js
+++ b/shape_circle.js
@@ -35,14 +35,6 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
       this.setCoords();
    },
 
-   /**
-    * Increment the size of the circle about its center.
-    */
-   incrementSize: function(increment) {
-      this.scaleToWidth(this.currentWidth + increment);
-      this.setCoords();
-   },
-
    toObject: function(propertiesToInclude) {
       return extend(this.callSuper('toObject', propertiesToInclude), {
          color: this.color,
@@ -62,6 +54,14 @@ mixin(proto, require('./highlighted_stroke.mixin'));
 mixin(proto, require('./limit_size'));
 mixin(proto, require('./nudge'));
 
+/**
+ * Increment the size of the circle about its center.
+ * Note: At the end so it overwrites the one in the `nudge` mixin
+ */
+proto.incrementSize = function(increment) {
+   this.scaleToWidth(this.currentWidth + increment);
+   this.setCoords();
+};
 
 Circle.fromObject = function(object) {
    return new Circle(object);

--- a/shape_circle.js
+++ b/shape_circle.js
@@ -4,7 +4,6 @@ var extend = Fabric.util.object.extend;
 var Circle = Fabric.util.createClass(Fabric.Circle, {
    // Inherited variables with new values.
    type: 'circle',
-   strokeWidth: 0,
    padding: 5,
    originX: 'center',
    originY: 'center',
@@ -22,21 +21,6 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
    // Min and Max size to enforce (false == no enforcement)
    minSize: false,
    maxSize: false,
-   borderWidth: 4,
-   outlineWidth: 1,
-   outlineStyle: '#FFF',
-
-   _stroke: function(ctx) {
-      var myScale = this.scaleX;
-      function scaleU(x) { return x / myScale; }
-      ctx.lineWidth = scaleU(this.borderWidth + this.outlineWidth);
-      ctx.strokeStyle = this.outlineStyle;
-      ctx.stroke();
-
-      ctx.lineWidth = scaleU(this.borderWidth - this.outlineWidth);
-      ctx.strokeStyle = this.stroke;
-      ctx.stroke();
-   },
 
    render: function(ctx) {
       this.callSuper('render', ctx);
@@ -77,6 +61,8 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
       });
    }
 });
+
+extend(Circle.prototype, require('./highlighted_stroke.mixin'));
 
 Circle.fromObject = function(object) {
    return new Circle(object);

--- a/shape_circle.js
+++ b/shape_circle.js
@@ -22,10 +22,6 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
    minSize: false,
    maxSize: false,
 
-   render: function(ctx) {
-      this.callSuper('render', ctx);
-   },
-
    /**
     * Resizes this shape using the two mouse coords (first is treated as the
     * center, second is the outside edge.

--- a/shape_circle.js
+++ b/shape_circle.js
@@ -39,7 +39,6 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
    },
 
    render: function(ctx) {
-      this._limitSize();
       this.callSuper('render', ctx);
    },
 
@@ -51,8 +50,10 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
       var xdiff = x2 - this.left;
       var ydiff = y2 - this.top;
       var radius = Math.sqrt(xdiff * xdiff + ydiff * ydiff);
-      this.scaleToWidth(radius * 2);
-      this.setCoords();
+      this._withSizeLimitations(function() {
+         this.scaleToWidth(this._limitDimension(radius * 2));
+         this.setCoords();
+      });
    },
 
    /**
@@ -60,20 +61,6 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
     */
    incrementSize: function(increment) {
       this.scaleToWidth(this.currentWidth + increment);
-      this.setCoords();
-   },
-
-   /**
-    * Enforce the min / max sizes if set.
-    */
-   _limitSize: function() {
-      var newRadius = this.getRadiusX();
-
-      if (this.minSize !== false && newRadius < this.minSize) {
-         this.scaleX = this.scaleY = this.minSize / this.radius;
-      } else if (this.maxSize !== false && newRadius > this.maxSize) {
-         this.scaleX = this.scaleY = this.maxSize / this.radius;
-      }
       this.setCoords();
    },
 
@@ -94,5 +81,8 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
 Circle.fromObject = function(object) {
    return new Circle(object);
 };
+
+extend(Circle.prototype, require('./limit_size'));
+extend(Circle.prototype, require('./nudge'));
 
 module.exports.klass = Circle;

--- a/shape_circle.js
+++ b/shape_circle.js
@@ -30,10 +30,8 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
       var xdiff = x2 - this.left;
       var ydiff = y2 - this.top;
       var radius = Math.sqrt(xdiff * xdiff + ydiff * ydiff);
-      this._withSizeLimitations(function() {
-         this.scaleToWidth(this._limitDimension(radius * 2));
-         this.setCoords();
-      });
+      this.scaleToWidth(this._limitDimension(radius * 2));
+      this.setCoords();
    },
 
    /**

--- a/shape_line.js
+++ b/shape_line.js
@@ -7,6 +7,7 @@ var Line = Fabric.util.createClass(Fabric.Line, {
    lockRotation: true,
    transparentCorners: false,
    hasRotatingPoint: false,
+   strokeLineCap: 'round',
    fill: 'transparent',
 
    // New fields.

--- a/shape_line.js
+++ b/shape_line.js
@@ -1,6 +1,6 @@
 var Fabric = require('fabric').fabric || fabric;
-var extend = Fabric.util.object.extend;
 var isNode = typeof window == 'undefined';
+var mixin = require('./mixin');
 
 var Line = Fabric.util.createClass(Fabric.Line, {
    type: 'line',
@@ -88,11 +88,15 @@ var Line = Fabric.util.createClass(Fabric.Line, {
    },
 });
 
+var proto = Line.prototype;
+mixin(proto, require('./highlighted_stroke.mixin'));
+mixin(proto, require('./limit_size'));
+mixin(proto, require('./nudge'));
+mixin(proto, require('./two_point_interactivity'));
+
+
 Line.fromObject = function(object) {
    return new Line(object);
 };
-
-extend(Line.prototype, require('./two_point_interactivity'));
-extend(Line.prototype, require('./highlighted_stroke.mixin'));
 
 module.exports.klass = Line;

--- a/shape_line.js
+++ b/shape_line.js
@@ -29,6 +29,13 @@ var Line = Fabric.util.createClass(Fabric.Line, {
       this.setCoords();
    },
 
+   render: function(ctx) {
+      var _this = this;
+      this._fixAndRestoreSubPixelPositioning(function() {
+         _this.callSuper('render', ctx, /* noTransform */ false);
+      });
+   },
+
    toMarkup: function(scale) {
       var points = this.getEndpoints();
       var p1 = points[0],
@@ -39,7 +46,46 @@ var Line = Fabric.util.createClass(Fabric.Line, {
           p2.x / scale + 'x' + p2.y / scale,
           this.color
       ].join(',') + ';';
-   }
+   },
+
+   /**
+    * If a line is perfectly vertical or horizontal and the outside edges of
+    * the borders are not lined up with pixels exactly, canvas will antialias
+    * them which looks bad.
+    *
+    * To prevent this, we calculate if the borders will be splitting pixels,
+    * adjust the positioning, call the callback and restore the position.
+    */
+   _fixAndRestoreSubPixelPositioning: function(callback) {
+      // In-browser we care more about fluidity than pixel-perfection, and
+      // having the outlines jump back and forth by one pixel as you resize it
+      // can be annoying.
+      // Also, this below logic only makes sense for perfectly vertical /
+      // horizontal lines so bail if that's not the case.
+      if (!isNode || (this.width > 1 && this.height > 1)) {
+         callback();
+         return;
+      }
+
+      var oldT = this.top,
+          oldL = this.left;
+
+      // Preconditions: width, height, borderWidth are all ints
+      // left, top represent the middle of the line
+      // Note x % 1 effectively does x - (int)x
+      var borderWidth = this.borderWidth + this.outlineWidth;
+      if (this.width <= 1) {
+         this.left -= (this.left + borderWidth / 2) % 1;
+      }
+      if (this.height <= 1) {
+         this.top -= (this.top + borderWidth / 2) % 1;
+      }
+
+      callback();
+
+      this.top  = oldT;
+      this.left = oldL;
+   },
 });
 
 Line.fromObject = function(object) {

--- a/shape_line.js
+++ b/shape_line.js
@@ -27,6 +27,18 @@ var Line = Fabric.util.createClass(Fabric.Line, {
       this.y2 = y2;
       this._setWidthHeight();
       this.setCoords();
+   },
+
+   toMarkup: function(scale) {
+      var points = this.getEndpoints();
+      var p1 = points[0],
+          p2 = points[1];
+      return [
+          'line',
+          p1.x / scale + 'x' + p1.y / scale,
+          p2.x / scale + 'x' + p2.y / scale,
+          this.color
+      ].join(',') + ';';
    }
 });
 

--- a/shape_line.js
+++ b/shape_line.js
@@ -12,19 +12,15 @@ var Line = Fabric.util.createClass(Fabric.Line, {
    // New fields.
    shapeName: 'line',
 
-   // Min and Max size to enforce (false == no enforcement)
-   minSize: false,
-   maxSize: false,
-
    /**
-    * Resizes this rectangle to make the most sense given the two points (they
+    * Resizes this line to make the most sense given the two points (they
     * will determine two opposite corners.
     */
    sizeByMousePos: function(x1, y1, x2, y2) {
       this.x1 = x1;
       this.y1 = y1;
-      this.x2 = x2;
-      this.y2 = y2;
+      this.x2 = x1 + this._limitDimension(x2 - x1);
+      this.y2 = y1 + this._limitDimension(y2 - y1);
       this._setWidthHeight();
       this.setCoords();
    },

--- a/shape_line.js
+++ b/shape_line.js
@@ -27,50 +27,11 @@ var Line = Fabric.util.createClass(Fabric.Line, {
    },
 
    render: function(ctx) {
-      var _this = this;
       this._fixAndRestoreSubPixelPositioning(function() {
-         _this.callSuper('render', ctx, /* noTransform */ false);
+         this.callSuper('render', ctx, /* noTransform */ false);
       });
    },
 
-   /**
-    * If a line is perfectly vertical or horizontal and the outside edges of
-    * the borders are not lined up with pixels exactly, canvas will antialias
-    * them which looks bad.
-    *
-    * To prevent this, we calculate if the borders will be splitting pixels,
-    * adjust the positioning, call the callback and restore the position.
-    */
-   _fixAndRestoreSubPixelPositioning: function(callback) {
-      // In-browser we care more about fluidity than pixel-perfection, and
-      // having the outlines jump back and forth by one pixel as you resize it
-      // can be annoying.
-      // Also, this below logic only makes sense for perfectly vertical /
-      // horizontal lines so bail if that's not the case.
-      if (!isNode || (this.width > 1 && this.height > 1)) {
-         callback();
-         return;
-      }
-
-      var oldT = this.top,
-          oldL = this.left;
-
-      // Preconditions: width, height, borderWidth are all ints
-      // left, top represent the middle of the line
-      // Note x % 1 effectively does x - (int)x
-      var borderWidth = this.borderWidth + this.outlineWidth;
-      if (this.width <= 1) {
-         this.left -= (this.left + borderWidth / 2) % 1;
-      }
-      if (this.height <= 1) {
-         this.top -= (this.top + borderWidth / 2) % 1;
-      }
-
-      callback();
-
-      this.top  = oldT;
-      this.left = oldL;
-   },
 });
 
 var proto = Line.prototype;

--- a/shape_line.js
+++ b/shape_line.js
@@ -18,10 +18,19 @@ var Line = Fabric.util.createClass(Fabric.Line, {
     * will determine two opposite corners.
     */
    sizeByMousePos: function(x1, y1, x2, y2) {
+      var xd = x2 - x1;
+      var yd = y2 - y1;
+      var rad = Math.sqrt(xd * xd + yd * yd);
+      if (!rad) {
+         xd = yd = this.minSize;
+         var ratio = 1;
+      } else {
+         var ratio = this._limitDimension(rad) / rad ;
+      }
       this.x1 = x1;
       this.y1 = y1;
-      this.x2 = x1 + this._limitDimension(x2 - x1);
-      this.y2 = y1 + this._limitDimension(y2 - y1);
+      this.x2 = x1 + ratio * xd;
+      this.y2 = y1 + ratio * yd;
       this._setWidthHeight();
       this.setCoords();
    },

--- a/shape_line.js
+++ b/shape_line.js
@@ -1,0 +1,40 @@
+var Fabric = require('fabric').fabric || fabric;
+var extend = Fabric.util.object.extend;
+var isNode = typeof window == 'undefined';
+
+var Line = Fabric.util.createClass(Fabric.Line, {
+   type: 'line',
+   lockRotation: true,
+   transparentCorners: false,
+   hasRotatingPoint: false,
+   fill: 'transparent',
+
+   // New fields.
+   shapeName: 'line',
+
+   // Min and Max size to enforce (false == no enforcement)
+   minSize: false,
+   maxSize: false,
+
+   /**
+    * Resizes this rectangle to make the most sense given the two points (they
+    * will determine two opposite corners.
+    */
+   sizeByMousePos: function(x1, y1, x2, y2) {
+      this.x1 = x1;
+      this.y1 = y1;
+      this.x2 = x2;
+      this.y2 = y2;
+      this._setWidthHeight();
+      this.setCoords();
+   }
+});
+
+Line.fromObject = function(object) {
+   return new Line(object);
+};
+
+extend(Line.prototype, require('./two_point_interactivity'));
+extend(Line.prototype, require('./highlighted_stroke.mixin'));
+
+module.exports.klass = Line;

--- a/shape_line.js
+++ b/shape_line.js
@@ -36,18 +36,6 @@ var Line = Fabric.util.createClass(Fabric.Line, {
       });
    },
 
-   toMarkup: function(scale) {
-      var points = this.getEndpoints();
-      var p1 = points[0],
-          p2 = points[1];
-      return [
-          'line',
-          p1.x / scale + 'x' + p1.y / scale,
-          p2.x / scale + 'x' + p2.y / scale,
-          this.color
-      ].join(',') + ';';
-   },
-
    /**
     * If a line is perfectly vertical or horizontal and the outside edges of
     * the borders are not lined up with pixels exactly, canvas will antialias

--- a/shape_rectangle.js
+++ b/shape_rectangle.js
@@ -30,9 +30,8 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
     */
    render: function(ctx) {
       this._resetScale();
-      var _this = this;
       this._fixAndRestoreSubPixelPositioning(function() {
-         _this.callSuper('render', ctx);
+         this.callSuper('render', ctx);
       });
    },
 
@@ -49,7 +48,7 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
       // having the outlines jump back and forth by one pixel as you resize it
       // can be annoying.
       if (!isNode) {
-         callback();
+         callback.call(this);
          return;
       }
 
@@ -77,7 +76,7 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
          this.height += partialY * 2;
       }
 
-      callback();
+      callback.call(this);
 
       this.width  = old.w;
       this.height = old.h;

--- a/shape_rectangle.js
+++ b/shape_rectangle.js
@@ -95,31 +95,28 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
       this.scaleX = this.scaleY = 1;
    },
 
-
    /**
     * Resizes this rectangle to make the most sense given the two points (they
     * will determine two opposite corners.
     */
    sizeByMousePos: function(x1, y1, x2, y2) {
-      this._withSizeLimitations(function() {
-         var xdiff = x2 - x1;
-         var ydiff = y2 - y1;
-         if (xdiff < 0) {
-            this.width = this._limitDimension(-xdiff);
-            this.left = x2 - (this.width - -xdiff);
-         } else {
-            this.width = this._limitDimension(xdiff);
-            this.left = x1;
-         }
-         if (ydiff < 0) {
-            this.height = this._limitDimension(-ydiff);
-            this.top = y2 - (this.height - -ydiff);
-         } else {
-            this.height = this._limitDimension(ydiff);
-            this.top = y1;
-         }
-         this.setCoords();
-      });
+      var xdiff = x2 - x1;
+      var ydiff = y2 - y1;
+      if (xdiff < 0) {
+         this.width = this._limitDimension(-xdiff);
+         this.left = x2 - (this.width - -xdiff);
+      } else {
+         this.width = this._limitDimension(xdiff);
+         this.left = x1;
+      }
+      if (ydiff < 0) {
+         this.height = this._limitDimension(-ydiff);
+         this.top = y2 - (this.height - -ydiff);
+      } else {
+         this.height = this._limitDimension(ydiff);
+         this.top = y1;
+      }
+      this.setCoords();
    },
 
    /**

--- a/shape_rectangle.js
+++ b/shape_rectangle.js
@@ -10,6 +10,7 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
    lockRotation: true,
    transparentCorners: false,
    hasRotatingPoint: false,
+   hasBorders: false,
    fill: 'transparent',
 
    // New fields.

--- a/shape_rectangle.js
+++ b/shape_rectangle.js
@@ -65,7 +65,7 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
 
       // If the left-most edge of the border is not directly on a pixel
       // then niether is the right-most border, 
-      var borderWidth = this.borderWidth + this.outlineWidth;
+      var borderWidth = this.borderWidth + (this.outlineWidth * this.borderWidth);
       var partialX = (this.left + borderWidth / 2) % 1;
       var partialY = (this.top + borderWidth / 2) % 1;
       if (partialX != 0) {

--- a/shape_rectangle.js
+++ b/shape_rectangle.js
@@ -5,7 +5,6 @@ var isNode = typeof window == 'undefined';
 var Rectangle = Fabric.util.createClass(Fabric.Rect, {
    // Inherited fields with new values.
    type: 'rectangle',
-   strokeWidth: 0,
    originX: 'left',
    originY: 'top',
    lockRotation: true,
@@ -19,25 +18,6 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
    // Min and Max size to enforce (false == no enforcement)
    minSize: false,
    maxSize: false,
-   borderWidth: 4,
-   outlineWidth: 1,
-   outlineStyle: '#FFF',
-
-   /**
-    * Provide a custom stroke function that draws a fat white line THEN a
-    * narrower colored line on top.
-    */
-   _stroke: function(ctx) {
-      var myScale = this.scaleX;
-      function scale(x) { return (x / myScale); }
-      ctx.lineWidth = scale(this.borderWidth + this.outlineWidth);
-      ctx.strokeStyle = this.outlineStyle;
-      ctx.stroke();
-
-      ctx.lineWidth = scale(this.borderWidth - this.outlineWidth);
-      ctx.strokeStyle = this.stroke;
-      ctx.stroke();
-   },
 
    /**
     * Wrap the underlying render function to do two things.
@@ -184,6 +164,8 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
       });
    }
 });
+
+extend(Rectangle.prototype, require('./highlighted_stroke.mixin'));
 
 Rectangle.fromObject = function(object) {
    return new Rectangle(object);

--- a/shape_rectangle.js
+++ b/shape_rectangle.js
@@ -1,6 +1,7 @@
 var Fabric = require('fabric').fabric || fabric;
 var extend = Fabric.util.object.extend;
 var isNode = typeof window == 'undefined';
+var mixin = require('./mixin');
 
 var Rectangle = Fabric.util.createClass(Fabric.Rect, {
    // Inherited fields with new values.
@@ -162,13 +163,13 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
    }
 });
 
-extend(Rectangle.prototype, require('./highlighted_stroke.mixin'));
+var proto = Rectangle.prototype;
+mixin(proto, require('./highlighted_stroke.mixin'));
+mixin(proto, require('./limit_size'));
+mixin(proto, require('./nudge'));
 
 Rectangle.fromObject = function(object) {
    return new Rectangle(object);
 };
-
-extend(Rectangle.prototype, require('./limit_size'));
-extend(Rectangle.prototype, require('./nudge'));
 
 module.exports.klass = Rectangle;

--- a/shape_rectangle.js
+++ b/shape_rectangle.js
@@ -120,29 +120,6 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
       this.setCoords();
    },
 
-   /**
-    * Increment the size of the rectangle about its center.
-    */
-   incrementSize: function(increment, axis) {
-      var portionW = this.width / (this.width + this.height);
-      if (axis == 'X') {
-         portionW = 1;
-      } else if (axis == 'Y') {
-         portionW = 0;
-      }
-      var deltaX = increment * portionW;
-      var deltaY = increment * (1 - portionW);
-      var newWidth = this.width + deltaX
-      var newHeight = this.height + deltaY
-
-      // Checks to see if the new size will be too big/small.
-      this.width = newWidth;
-      this.height = newHeight;
-      this.left -= deltaX / 2;
-      this.top -= deltaY / 2;
-      this.setCoords();
-   },
-
    center: function() {
       this.centerTransform = true;
       this.callSuper('center');

--- a/two_point_interactivity.js
+++ b/two_point_interactivity.js
@@ -3,6 +3,7 @@ module.exports = (function(){
    var Fabric = require('fabric').fabric || fabric;
 
    return {
+      _limitByDiagonal: true,
 
       /**
        * Intercept the set('scaleX') calls during resize so we can flip the

--- a/two_point_interactivity.js
+++ b/two_point_interactivity.js
@@ -111,6 +111,18 @@ module.exports = (function(){
             x: (left - halfWidth * flipX),
             y: (top - halfHeight * flipY)
          }];
+      },
+
+      toMarkup: function(scale) {
+         var points = this.getEndpoints();
+         var p1 = points[0],
+             p2 = points[1];
+         return [
+             this.type,
+             p1.x / scale + 'x' + p1.y / scale,
+             p2.x / scale + 'x' + p2.y / scale,
+             this.color
+         ].join(',') + ';';
       }
    }
 })();

--- a/two_point_interactivity.js
+++ b/two_point_interactivity.js
@@ -77,6 +77,26 @@ module.exports = (function(){
    
          ctx.restore();
          return self;
+      },
+
+      getEndpoints: function() {
+         var self = this;
+         var flipX = self.x1 > self.x2 ? 1 : -1;
+         var flipY = self.y1 > self.y2 ? 1 : -1;
+         // Objects in fabric can't have 0-width, so a vertical line ends up
+         // with witdth = 1 so we detect that and ensure the midpoint isn't on
+         // a pixel boundary and the width actually ends up 0.
+         var halfWidth  = self.width  === 1 ? 0 : self.width / 2;
+         var halfHeight = self.height === 1 ? 0 : self.height / 2;
+         var left = self.width  === 1 ? Math.floor(self.left) : self.left;
+         var top  = self.height === 1 ? Math.floor(self.top)  : self.top;
+         return [{
+            x: (left + halfWidth * flipX),
+            y: (top + halfHeight * flipY)
+         },{
+            x: (left - halfWidth * flipX),
+            y: (top - halfHeight * flipY)
+         }];
       }
    }
 })();

--- a/two_point_interactivity.js
+++ b/two_point_interactivity.js
@@ -75,7 +75,7 @@ module.exports = (function(){
          ctx.beginPath();
  
          function circle(x,y) {
-            ctx.arc(x, y, self.cornerSize/2, 0, 2 * Math.PI, false);
+            ctx.arc(x, y, self.cornerSize/1.4, 0, 2 * Math.PI, false);
          }
    
          var flipX = self.x1 > self.x2 ? 1 : -1;

--- a/two_point_interactivity.js
+++ b/two_point_interactivity.js
@@ -20,7 +20,7 @@ module.exports = (function(){
             this.y1 = this.y2; this.y2 = y1;
          }
 
-         this.callSuper('_set', key, value);
+         this.callParent(key, value);
          this._resetScale();
          return this;
       },

--- a/two_point_interactivity.js
+++ b/two_point_interactivity.js
@@ -51,7 +51,6 @@ module.exports = (function(){
          this.scaleY = 1;
       },
 
-
       /**
        * We don't want line-based shapes to have a bounding box (it looks dumb
        * around lines.

--- a/two_point_interactivity.js
+++ b/two_point_interactivity.js
@@ -92,6 +92,35 @@ module.exports = (function(){
          return self;
       },
 
+      /**
+       * If a line is perfectly vertical or horizontal and the outside edges of
+       * the borders are not lined up with pixels exactly, canvas will antialias
+       * them which looks bad.
+       *
+       * To prevent this, we calculate if the borders will be splitting pixels,
+       * adjust the positioning, call the callback and restore the position.
+       */
+      _fixAndRestoreSubPixelPositioning: function(callback) {
+         var oldT = this.top,
+             oldL = this.left;
+
+         // Preconditions: width, height, borderWidth are all ints
+         // left, top represent the middle of the line
+         // Note x % 1 effectively does x - (int)x
+         var borderWidth = this.borderWidth + (this.outlineWidth * this.borderWidth);
+         if (this.width <= 1) {
+            this.left -= (this.left + borderWidth / 2) % 1;
+         }
+         if (this.height <= 1) {
+            this.top -= (this.top + borderWidth / 2) % 1;
+         }
+
+         callback.call(this);
+
+         this.top  = oldT;
+         this.left = oldL;
+      },
+
       getEndpoints: function() {
          var self = this;
          var flipX = self.x1 > self.x2 ? 1 : -1;

--- a/two_point_interactivity.js
+++ b/two_point_interactivity.js
@@ -1,0 +1,82 @@
+module.exports = (function(){
+
+   var Fabric = require('fabric').fabric || fabric;
+
+   return {
+
+      /**
+       * Intercept the set('scaleX') calls during resize so we can flip the
+       * order of the points when the cursor crosses the origin. Also, we reset
+       * the scale to 1 and apply it to the width and height so there isn't a
+       * scale transform present when drawing the stroke.
+       */
+      _set: function(key, value) {
+         if (key === 'scaleX' && value < 0) {
+            var x1 = this.x1
+            this.x1 = this.x2; this.x2 = x1;
+         }
+         else if (key === 'scaleY' && value < 0) {
+            var y1 = this.y1
+            this.y1 = this.y2; this.y2 = y1;
+         }
+
+         this.callSuper('_set', key, value);
+         this._resetScale();
+         return this;
+      },
+
+      /**
+       * Apply the scaling to the width and height and set scale to 1 so
+       * that stroke width is independent of the scale transform
+       */
+      _resetScale: function() {
+         // There is a brief period (one frame) where the 
+         this.width = this.width * Math.abs(this.scaleX);
+         this.height = this.height * Math.abs(this.scaleY);
+         this.scaleX = 1;
+         this.scaleY = 1;
+      },
+
+
+      /**
+       * We don't want line-based shapes to have a bounding box (it looks dumb
+       * around lines.
+       */
+      drawBorders: function(ctx) {
+         return this;
+      },
+
+      /**
+       * Override the `drawControls` to only draw handles at endpoints of the
+       * line (two corners of the bounding box) instead of all corners and all
+       * midpoints.
+       */
+      drawControls: function(ctx) {
+         var self = this;
+         if (!this.hasControls) return self;
+   
+         ctx.save();
+         ctx.lineWidth = 1 / Math.max(self.scaleX, self.scaleY);
+         ctx.globalAlpha = 0.9;
+         ctx.strokeStyle = ctx.fillStyle = self.cornerColor;
+         ctx.beginPath();
+ 
+         function circle(x,y) {
+            ctx.arc(x, y, self.cornerSize/2, 0, 2 * Math.PI, false);
+         }
+   
+         var flipX = self.x1 > self.x2 ? 1 : -1;
+         var flipY = self.y1 > self.y2 ? 1 : -1;
+         var halfWidth = self.width / 2;
+         var halfHeight = self.height / 2;
+         // In this context, 0,0 is the center of the line so we draw a handle
+         // half of the line length away from the origin in both directions.
+         circle(halfWidth * flipX, halfHeight * flipY);
+         circle(-halfWidth * flipX, -halfHeight * flipY);
+         ctx.fill();
+   
+         ctx.restore();
+         return self;
+      }
+   }
+})();

--- a/two_point_interactivity.js
+++ b/two_point_interactivity.js
@@ -30,9 +30,23 @@ module.exports = (function(){
        * that stroke width is independent of the scale transform
        */
       _resetScale: function() {
-         // There is a brief period (one frame) where the 
-         this.width = this.width * Math.abs(this.scaleX);
-         this.height = this.height * Math.abs(this.scaleY);
+         // There is a brief period where scaleX == 0 and fabric.js disappears
+         // objects that have width = 0 so we can't let that happen.
+         if (this.scaleX == 0) {
+            this.width = 1
+         } else {
+            // Note: there is a brief period (one frame) where the scale goes
+            // negative when the resize control crosses an axis. Using abs()
+            // keeps the motion fluid instead of a few pixel jump.
+            this.width *= Math.abs(this.scaleX);
+         }
+
+         if (this.scaleY == 0) {
+            this.height = 1;
+         } else {
+            this.height *= Math.abs(this.scaleY);
+         }
+
          this.scaleX = 1;
          this.scaleY = 1;
       },
@@ -67,8 +81,8 @@ module.exports = (function(){
    
          var flipX = self.x1 > self.x2 ? 1 : -1;
          var flipY = self.y1 > self.y2 ? 1 : -1;
-         var halfWidth = self.width / 2;
-         var halfHeight = self.height / 2;
+         var halfWidth  = self.width  === 1 ? 0 : self.width / 2;
+         var halfHeight = self.height === 1 ? 0 : self.height / 2;
          // In this context, 0,0 is the center of the line so we draw a handle
          // half of the line length away from the origin in both directions.
          circle(halfWidth * flipX, halfHeight * flipY);


### PR DESCRIPTION
* New two_point_interactivity.js mixin
   * Should be the basis for all line-based shapes: arrows, lines, gap
     markers.
   * Handles scaling, controls, creation via mouse, sub-pixel alignment,
     conversion to markup
* New highlighted_stroke.js mixin so code is re-used across all shapes
* Change white 1px border to be proportional to line thickness across
  all shapes
   * Previously it was only 1px wide no matter the resolution of the
     image.
* Moved incrementSize() to the nudge.js mixin
* Added mixin.js to compose mixins while allowing each to call the
  parent function.