### PR TITLE
Fix Fabric.js git reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url"         : "git://github.com/iFixit/node-markup.git"
   },
   "dependencies"    : {
-    "fabric"      : "git://github.com/iFixit/fabric.js.git#ifixit-production"
+    "fabric"      : "git://github.com/iFixit/fabric.js.git"
    ,"optimist"    : "git://github.com/substack/node-optimist.git"
    ,"gm"          : ">=1.8.1"
   },


### PR DESCRIPTION
We've merged `ifixit-production` into master on Fabric.js here:
https://github.com/iFixit/fabric.js/pull/1

This repo no longer builds correctly from the `ifixit-production` branch. We need to ref master now.

CC @andyg0808 @danielbeardsley 