### PR TITLE
Move to HTTPS for our git cloning URLs.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "node_modules/fabric"]
 	path = node_modules/fabric
-	url = git://github.com/iFixit/fabric.js.git
+	url = https://github.com/iFixit/fabric.js.git

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   ],
   "repository"      : {
     "type"        : "git",
-    "url"         : "git://github.com/iFixit/node-markup.git"
+    "url"         : "https://github.com/iFixit/node-markup.git"
   },
   "dependencies"    : {
-    "fabric"      : "git://github.com/iFixit/fabric.js.git"
-   ,"optimist"    : "git://github.com/substack/node-optimist.git"
+    "fabric"      : "https://github.com/iFixit/fabric.js.git"
+   ,"optimist"    : "https://github.com/substack/node-optimist.git"
    ,"gm"          : ">=1.8.1"
   },
   "version"         : "0.0.2"


### PR DESCRIPTION
GitHub as disabled the `git://` protocol for security reasons. (See: https://github.blog/2021-09-01-improving-git-protocol-security-github/). This updates a few repo references to use `https://` instead.