### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM fedora:32
+
+RUN mkdir -p /opt/node-markup
+WORKDIR /opt/node-markup
+
+RUN curl -sL -o node.rpm https://rpm.nodesource.com/pub_6.x/fc/26/x86_64/nodesource-release-fc26-1.noarch.rpm \
+ && rpm -ivh node.rpm \
+ && dnf remove -y nodejs npm || true \
+ && dnf install -y nodejs
+
+RUN npm config set umask 002 \
+ && npm config set unsafe-perm true \
+ && npm install -g npm@6.13.7 strip-ansi@3.0.1
+
+RUN npm version
+
+RUN npm build /usr/lib/node_modules/*
+
+RUN dnf -y install \
+ python \
+ GraphicsMagick \
+ gcc-c++ \
+ perl-Digest-SHA \
+ cairo cairo-devel \
+ cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel giflib-devel \
+ git make which
+
+RUN npm install -g --verbose node-gyp \
+ && npm install -g --verbose canvas@1.x
+
+COPY . .
+
+RUN npm install
+
+RUN ./run-tests.py


### PR DESCRIPTION
This scrapes together an approximation of the normal app environment,
with node 6 on Fedora 32, a specific version of `npm` and `canvas`.

This gets the main `npm install` working, and passes the python tests.

This should help to facilitate further upgrades.

Ref: (closes?) https://github.com/iFixit/ifixit/issues/43752

CC @iFixit/devops 