### PR TITLE
Replace Optimist with Yargs

### DIFF
--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -1,6 +1,6 @@
 var ImageMarkupBuilder = require('./ImageMarkupBuilder').Builder;
 var Fabric = require('fabric').fabric;
-var argv = require('optimist').argv;
+var argv = require('yargs').argv;
 
 var colorValues = {
    'red': 'rgb(193,40,11)',

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies"    : {
     "fabric"      : "https://github.com/iFixit/fabric.js.git"
-   ,"optimist"    : "https://github.com/substack/node-optimist.git"
-   ,"gm"          : ">=1.8.1"
+   ,"gm"          : ">=1.8.1",
+   "yargs": "^13.3.2"
   },
   "version"         : "0.0.2"
 }

--- a/validator/ValidateJSON.js
+++ b/validator/ValidateJSON.js
@@ -1,6 +1,6 @@
 var sys = require('sys'),
     fs = require('fs'),
-    argv = require('optimist')
+    argv = require('yargs')
       .usage('Validate against a schema with a JSON file\n' +
              'Usage: $0 --schema [schema_file] --json [json_file]')
       .demand('schema')


### PR DESCRIPTION
Optimist is [deprecated](https://github.com/substack/node-optimist#deprecation-notice), and has some troublesome dependencies. Specifically, `contextify` on later versions of node. It appears that yargs is a nearly drop-in replacement for optimisit.

[Yargs]() is the well worn successor to optimist. It appears to drop in and work.

CC @iFixit/devops 