### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN dnf -y install \
 
 RUN npm install -g --verbose node-gyp
 
-COPY . .
-
+COPY package.json .
 RUN npm install
+COPY . .
 
 RUN ./run-tests.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ RUN dnf -y install \
  cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel giflib-devel \
  git make which
 
-RUN npm install -g --verbose node-gyp \
- && npm install -g --verbose canvas@1.x
+RUN npm install -g --verbose node-gyp
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,7 @@ RUN curl -sL -o node.rpm https://rpm.nodesource.com/pub_6.x/fc/26/x86_64/nodesou
 
 RUN npm config set umask 002 \
  && npm config set unsafe-perm true \
- && npm install -g npm@6.13.7 strip-ansi@3.0.1
-
-RUN npm version
+ && npm install -g npm@6.13.7 strip-ansi@3.0.1 && npm version
 
 RUN npm build /usr/lib/node_modules/*
 


### PR DESCRIPTION
Improve our Dockerfile.

3 Main improvements:
- Fold together two layers that we do not need to separate. The `npm version` check was for debug, and to verify the fix for the `npm install npm` bug we were seeing. That does not need an independent layer.
- Drop installing `canvas` from the system. We'll pull in the specified version of `canvas` via the main app `npm install`. 
- Split install npm deps from the main code.
   - This is a nice quality-of-life improvement, as it better leverages docker layer caching. We only really need an `npm install` if we change our `package.json`.
 