### PR TITLE
Cleanup helper functions

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -95,6 +95,7 @@ function ImageMarkupBuilder(fabricCanvas) {
         ,'width'
         ,'height'
         ,'radius'
+        ,'strokeWidth'
       ];
       const isIntegerProperty = (property) => integerProperties.indexOf(property) != -1;
 

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -89,13 +89,20 @@ function ImageMarkupBuilder(fabricCanvas) {
       if (!context)
          context = "root";
 
+      var integerProperties = [
+         'x'
+        ,'y'
+        ,'width'
+        ,'height'
+        ,'radius'
+      ];
+      const isIntegerProperty = (property) => integerProperties.indexOf(property) != -1;
+
       for (var property in json) {
          if (typeof(json[property]) == 'object') {
             cleanJSON(json[property], context + '.' + property);
          }
-         else if (property == 'x' || property == 'y' ||
-          property == 'width' || property == 'height' ||
-          property == 'radius') {
+         else if (isIntegerProperty(property)) {
             if (typeof(json[property]) == 'string') {
              json[property] = parseInt(json[property]);
                if (isNaN(json[property])) {

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -1,3 +1,5 @@
+const { cleanJSON } = require('./src/utils');
+
 var isNode = typeof window == 'undefined';
 
 /**
@@ -78,42 +80,6 @@ function ImageMarkupBuilder(fabricCanvas) {
               rect.left + (strokeWidth * 2) > this.width ||
               rect.top + rect.height - (strokeWidth * 2) < 0 ||
               rect.top + (strokeWidth * 2) > this.height);
-   }
-
-   /**
-    * Cycles through an object and changes all numeric fields to ints
-    * where necessary. 'context' is used for exception reporting and can be
-    * left unset upon invocation.
-    */
-   function cleanJSON(json, context) {
-      if (!context)
-         context = "root";
-
-      var integerProperties = [
-         'x'
-        ,'y'
-        ,'width'
-        ,'height'
-        ,'radius'
-        ,'strokeWidth'
-      ];
-      const isIntegerProperty = (property) => integerProperties.indexOf(property) != -1;
-
-      for (var property in json) {
-         if (typeof(json[property]) == 'object') {
-            cleanJSON(json[property], context + '.' + property);
-         }
-         else if (isIntegerProperty(property)) {
-            if (typeof(json[property]) == 'string') {
-             json[property] = parseInt(json[property]);
-               if (isNaN(json[property])) {
-                  var msg = "In '" + context + "': property '" + property +
-                   "' is not a number.";
-                  throw msg;
-               }
-            }
-         }
-      }
    }
 
    function applyBackground(callback) {

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -80,23 +80,6 @@ function ImageMarkupBuilder(fabricCanvas) {
               rect.top + (strokeWidth * 2) > this.height);
    }
 
-
-   /**
-    * Simple clone function for use in deep-copying objects containing
-    * objects, arrays, and values. Does not support copying of functions.
-    */
-   function clone(obj) {
-      var newobj = {};
-      for (var property in obj) {
-         if (typeof obj[property] == 'object') {
-            newobj[property] = clone(property);
-         } else {
-            newobj[property] = obj[property];
-         }
-      }
-      return newobj;
-   }
-
    /**
     * Cycles through an object and changes all numeric fields to ints
     * where necessary. 'context' is used for exception reporting and can be

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -1,4 +1,4 @@
-var { Int } = require('./src/utils');
+var { Int, cleanJSON } = require('./src/utils');
 var ImageMarkupBuilder = require('./ImageMarkupBuilder').Builder;
 var Fabric = require('fabric').fabric;
 var argv = require('optimist').argv;
@@ -213,42 +213,6 @@ function processJSON(json) {
          console.log(builder.getMarkupString());
       }
    });
-}
-
-/**
- * Cycles through an object and changes all numeric fields to ints
- * where necessary. 'context' is used for exception reporting and can be
- * left unset upon invocation.
- */
-function cleanJSON(json, context) {
-   if (!context)
-      context = "root";
-
-   var integerProperties = [
-      'x'
-     ,'y'
-     ,'width'
-     ,'height'
-     ,'radius'
-     ,'strokeWidth'
-   ];
-   const isIntegerProperty = (property) => integerProperties.indexOf(property) != -1;
-
-   for (var property in json) {
-
-      if (typeof(json[property]) == 'object') {
-         cleanJSON(json[property], context + '.' + property);
-      } else if (isIntegerProperty(property)) {
-         if (typeof(json[property]) == 'string') {
-            json[property] = Int(json[property]);
-            if (isNaN(json[property])) {
-               var msg = "In '" + context + "': property '" + property
-                + "' is not a number.";
-               throw msg;
-            }
-         }
-      }
-   }
 }
 
 processArgs();

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -1,3 +1,4 @@
+var { Int } = require('./src/utils');
 var ImageMarkupBuilder = require('./ImageMarkupBuilder').Builder;
 var Fabric = require('fabric').fabric;
 var argv = require('optimist').argv;
@@ -272,13 +273,6 @@ function cleanJSON(json, context) {
          }
       }
    }
-}
-
-/**
- * Just like parseInt, but fixed to base-10
- */
-function Int(str) {
-   return parseInt(str, 10);
 }
 
 processArgs();

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -232,12 +232,13 @@ function cleanJSON(json, context) {
      ,'radius'
      ,'strokeWidth'
    ];
+   const isIntegerProperty = (property) => integerProperties.indexOf(property) != -1;
 
    for (var property in json) {
 
       if (typeof(json[property]) == 'object') {
          cleanJSON(json[property], context + '.' + property);
-      } else if (integerProperties.indexOf(property) != -1) {
+      } else if (isIntegerProperty(property)) {
          if (typeof(json[property]) == 'string') {
             json[property] = Int(json[property]);
             if (isNaN(json[property])) {

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -216,31 +216,6 @@ function processJSON(json) {
 }
 
 /**
- * Pretty-prints a JSON object to the console. The first invocation not set the
- * 'level' parameter.
- */
-function printJSON(json, level) {
-   String.prototype.repeat = function (num) {
-      return new Array(num+1).join(this);
-   }
-   if (!level) {
-      console.log("{");
-      printJSON(json, 1);
-      console.log("}");
-   } else {
-      for (var property in json) {
-         console.log("\t".repeat(level) + property + ": " + json[property] +
-          " [" + typeof(json[property]) + "]");
-         if (typeof(json[property]) == 'object') {
-            console.log("\t".repeat(level) + "{");
-            printJSON(json[property], level+1);
-            console.log("\t".repeat(level) + "}");
-         }
-      }
-   }
-}
-
-/**
  * Cycles through an object and changes all numeric fields to ints
  * where necessary. 'context' is used for exception reporting and can be
  * left unset upon invocation.

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,4 +5,40 @@ module.exports = {
   Int: function (str) {
      return parseInt(str, 10);
   },
+
+  /**
+   * Cycles through an object and changes all numeric fields to ints
+   * where necessary. 'context' is used for exception reporting and can be
+   * left unset upon invocation.
+   */
+  cleanJSON: function cleanJSON(json, context) {
+     if (!context)
+        context = "root";
+
+     var integerProperties = [
+        'x'
+       ,'y'
+       ,'width'
+       ,'height'
+       ,'radius'
+       ,'strokeWidth'
+     ];
+     const isIntegerProperty = (property) => integerProperties.indexOf(property) != -1;
+
+     for (var property in json) {
+        if (typeof(json[property]) == 'object') {
+           cleanJSON(json[property], context + '.' + property);
+        }
+        else if (isIntegerProperty(property)) {
+           if (typeof(json[property]) == 'string') {
+            json[property] = parseInt(json[property]);
+              if (isNaN(json[property])) {
+                 var msg = "In '" + context + "': property '" + property +
+                  "' is not a number.";
+                 throw msg;
+              }
+           }
+        }
+     }
+  }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,44 +1,47 @@
-module.exports = {
-  /**
-   * Just like parseInt, but fixed to base-10
-   */
-  Int(str) {
-     return parseInt(str, 10);
-  },
+/**
+* Just like parseInt, but fixed to base-10
+*/
+function Int(str) {
+  return parseInt(str, 10);
+}
 
-  /**
-   * Cycles through an object and changes all numeric fields to ints
-   * where necessary. 'context' is used for exception reporting and can be
-   * left unset upon invocation.
-   */
-  cleanJSON: function cleanJSON(json, context) {
-     if (!context)
-        context = "root";
+/**
+* Cycles through an object and changes all numeric fields to ints
+* where necessary. 'context' is used for exception reporting and can be
+* left unset upon invocation.
+*/
+function cleanJSON(json, context) {
+  if (!context)
+     context = "root";
 
-     var integerProperties = [
-        'x'
-       ,'y'
-       ,'width'
-       ,'height'
-       ,'radius'
-       ,'strokeWidth'
-     ];
-     const isIntegerProperty = (property) => integerProperties.indexOf(property) != -1;
+  var integerProperties = [
+     'x'
+    ,'y'
+    ,'width'
+    ,'height'
+    ,'radius'
+    ,'strokeWidth'
+  ];
+  const isIntegerProperty = (property) => integerProperties.indexOf(property) != -1;
 
-     for (var property in json) {
-        if (typeof(json[property]) == 'object') {
-           cleanJSON(json[property], context + '.' + property);
-        }
-        else if (isIntegerProperty(property)) {
-           if (typeof(json[property]) == 'string') {
-            json[property] = Int(json[property]);
-              if (isNaN(json[property])) {
-                 var msg = "In '" + context + "': property '" + property +
-                  "' is not a number.";
-                 throw msg;
-              }
+  for (var property in json) {
+     if (typeof(json[property]) == 'object') {
+        cleanJSON(json[property], context + '.' + property);
+     }
+     else if (isIntegerProperty(property)) {
+        if (typeof(json[property]) == 'string') {
+         json[property] = Int(json[property]);
+           if (isNaN(json[property])) {
+              var msg = "In '" + context + "': property '" + property +
+               "' is not a number.";
+              throw msg;
            }
         }
      }
   }
+}
+
+module.exports = {
+   Int,
+   cleanJSON,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,8 @@
+module.exports = {
+  /**
+   * Just like parseInt, but fixed to base-10
+   */
+  Int: function (str) {
+     return parseInt(str, 10);
+  },
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ module.exports = {
   /**
    * Just like parseInt, but fixed to base-10
    */
-  Int: function (str) {
+  Int(str) {
      return parseInt(str, 10);
   },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,7 +31,7 @@ module.exports = {
         }
         else if (isIntegerProperty(property)) {
            if (typeof(json[property]) == 'string') {
-            json[property] = parseInt(json[property]);
+            json[property] = Int(json[property]);
               if (isNaN(json[property])) {
                  var msg = "In '" + context + "': property '" + property +
                   "' is not a number.";


### PR DESCRIPTION
Lets clean up some of the stray helper functions in our main JS entrypoint modules.

The `clone` and `printJSON` helpers appear to be unused. Drop those.

The `cleanJSON` functions were interesting. I believe that the subtle difference between the integer property lists might have actually been a latent bug. Note especially that the server-side `ImageMarkupCall` outer/wrapper module _was_ performing the clean on the `strokeWidth` property. So that is a bug that can only be exposed on the clientside! See: https://github.com/iFixit/node-markup/commit/d77b777832a34476aa9e791fb248dd9c90caac22

With the two implementations unified and reconciled, we can reuse the same function from the new `utils` module. See: https://github.com/iFixit/node-markup/commit/7e3a82e4bef5905aa73a74ea46d98901b24d96ff