### PR TITLE
Prettier docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Node Markup #
+# Node Markup
 
-## About ##
+## About
 
 Node Markup is a helper library for
 [kangax's Fabric.js][fabricjs] to make it easier to
@@ -8,27 +8,27 @@ crop images and add markup such as circles and rectangles. Node Markup has
 frontend (web site) and backend (Node.js) support for rendering identical
 images on both sides.
 
-## Installation ##
+## Installation
 
-### Backend ###
+### Backend
 
 1. [Install Node.js][nodejs_install]
 2. Install Node Markup dependencies
 
-     `$ npm install`
+   `$ npm install`
 
 3. From the terminal, you can call ImageMarkupCall.js
 
-     `$ node ImageMarkupCall.js --json '[json_string]'`
+   `$ node ImageMarkupCall.js --json '[json_string]'`
 
-### Frontend ###
+### Frontend
 
-***TODO:*** The JSON schema is mostly undocumented, and the frontend works in a
+**_TODO:_** The JSON schema is mostly undocumented, and the frontend works in a
 very different way from the backend, so the frontend will be more or less
 trial-and-error for the user (you) until I've finished documenting it.
 
-* Do not include sourceFile or destinationFile in the frontend JSON. You can
-add a source image manually to the Fabric.js canvas, or leave it blank.
+- Do not include sourceFile or destinationFile in the frontend JSON. You can
+  add a source image manually to the Fabric.js canvas, or leave it blank.
 
 Long story short:
 
@@ -38,15 +38,15 @@ Long story short:
 
 3. Run that `<canvas>` object through `fabric.Canvas`
 
-     `var fabric = new fabric.Canvas('canvasid');`
+   `var fabric = new fabric.Canvas('canvasid');`
 
 4. Run that fabric object trough `ImageMarkupBuilder`
 
-     `var markupBuilder = new ImageMarkupBuilder(fabric);`
+   `var markupBuilder = new ImageMarkupBuilder(fabric);`
 
-5. Send a JSON **object** *(not string)* through for processing
+5. Send a JSON **object** _(not string)_ through for processing
 
-     `markupBuilder.processJSON(jsonObject);`
+   `markupBuilder.processJSON(jsonObject);`
 
 [fabricjs]: https://github.com/kangax/fabric.js/
 [nodejs_install]: https://github.com/joyent/node/wiki/Installation

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,45 +1,45 @@
-# Builder JSON #
+# Builder JSON
 
-## Introduction ##
+## Introduction
 
 The Builder JSON format provides instructions to Node Markup's `ImageMarkupBuilder` (or `ImageMarkupCall` if done from command line).
 
-## Specification ##
+## Specification
 
 The Builder JSON schema is made up of the following top elements:
 
-* `dimensions`: The original dimensions of the image/canvas. This is a (`height`, `width`) tuple.
-* `finalDimensions`: The final dimensions of the image/canvas. This is a (`height`, `width`) tuple.
-* `instructions`: A set of image modifcation instructions (described below).
+- `dimensions`: The original dimensions of the image/canvas. This is a (`height`, `width`) tuple.
+- `finalDimensions`: The final dimensions of the image/canvas. This is a (`height`, `width`) tuple.
+- `instructions`: A set of image modifcation instructions (described below).
 
-####*Node.js-specific elements*####
+####_Node.js-specific elements_####
 
-* `sourceFile`: The source JPEG to apply markup instructions to.
-* `destinationFile`: The destination JPEG to save to.
+- `sourceFile`: The source JPEG to apply markup instructions to.
+- `destinationFile`: The destination JPEG to save to.
 
-####*Frontend- or HTML-specific elements*####
+####_Frontend- or HTML-specific elements_####
 
-* `previewInstructions`: Instructions (described below) to support downsizing an image to fit in a smaller container.
+- `previewInstructions`: Instructions (described below) to support downsizing an image to fit in a smaller container.
 
       * `ratio`: The ratio of original size to preview size. For example, if the original image width is 1024px and the preview container size is 640px, `ratio = 1024 / 640 = 1.6`.
 
-*If `previewInstructions.ratio` is specified, give absolute pixel coordinates/sizes in `draw` instructions based on the preview size. They will be upscaled automatically.*
+_If `previewInstructions.ratio` is specified, give absolute pixel coordinates/sizes in `draw` instructions based on the preview size. They will be upscaled automatically._
 
 ###Instructions Specification###
 
 `instructions` is a set of markup instructions:
 
-* `crop`: Instructions to crop the image
+- `crop`: Instructions to crop the image
 
       * `from`: Top-left pixel coordinates of crop. This is an (`x`, `y`) tuple.
 
       * `size`: Pixel size of crop. This is a (`height`, `width`) tuple.
 
-* `draw`: An array of markup drawing instructions (described below)
+- `draw`: An array of markup drawing instructions (described below)
 
 ####Markup Drawing Instructions####
 
-* `circle`: Instructions to draw a circle
+- `circle`: Instructions to draw a circle
 
       * `color`: A color name (e.g. 'red')
 
@@ -47,7 +47,7 @@ The Builder JSON schema is made up of the following top elements:
 
       * `radius`: The pixel radius of the circle
 
-* `rectangle`: Instructions to draw a rectangle
+- `rectangle`: Instructions to draw a rectangle
 
       * `color`: A color name (e.g. 'red')
 
@@ -55,7 +55,7 @@ The Builder JSON schema is made up of the following top elements:
 
       * size: A (`height`, `width`) tuple of the size of the rectangle.
 
-## Sample JSON String ##
+## Sample JSON String
 
 <!-- prettier-ignore -->
 `{
@@ -108,7 +108,7 @@ The Builder JSON schema is made up of the following top elements:
   "destinationFile": ".\/destination.jpg"
 }`
 
-# Builder Markup String #
+# Builder Markup String
 
 `ImageMarkupCall` supports a semicolon-separated Markup string for more compact drawing instruction specification.
 
@@ -118,7 +118,7 @@ Example:
 
 `crop,330x330,2588x1941;circle,1921x466,70,black;rectangle,369x973,131x131,red;rectangle,1602x605,131x131,black`
 
-## Specification ##
+## Specification
 
 `crop,[x],[y],[width]x[height]`
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,45 +1,45 @@
-# Builder JSON #
+# Builder JSON
 
-## Introduction ##
+## Introduction
 
 The Builder JSON format provides instructions to Node Markup's `ImageMarkupBuilder` (or `ImageMarkupCall` if done from command line).
 
-## Specification ##
+## Specification
 
 The Builder JSON schema is made up of the following top elements:
 
-* `dimensions`: The original dimensions of the image/canvas. This is a (`height`, `width`) tuple.
-* `finalDimensions`: The final dimensions of the image/canvas. This is a (`height`, `width`) tuple.
-* `instructions`: A set of image modifcation instructions (described below).
+- `dimensions`: The original dimensions of the image/canvas. This is a (`height`, `width`) tuple.
+- `finalDimensions`: The final dimensions of the image/canvas. This is a (`height`, `width`) tuple.
+- `instructions`: A set of image modifcation instructions (described below).
 
-####*Node.js-specific elements*####
+####_Node.js-specific elements_####
 
-* `sourceFile`: The source JPEG to apply markup instructions to.
-* `destinationFile`: The destination JPEG to save to.
+- `sourceFile`: The source JPEG to apply markup instructions to.
+- `destinationFile`: The destination JPEG to save to.
 
-####*Frontend- or HTML-specific elements*####
+####_Frontend- or HTML-specific elements_####
 
-* `previewInstructions`: Instructions (described below) to support downsizing an image to fit in a smaller container.
+- `previewInstructions`: Instructions (described below) to support downsizing an image to fit in a smaller container.
 
       * `ratio`: The ratio of original size to preview size. For example, if the original image width is 1024px and the preview container size is 640px, `ratio = 1024 / 640 = 1.6`.
 
-*If `previewInstructions.ratio` is specified, give absolute pixel coordinates/sizes in `draw` instructions based on the preview size. They will be upscaled automatically.*
+_If `previewInstructions.ratio` is specified, give absolute pixel coordinates/sizes in `draw` instructions based on the preview size. They will be upscaled automatically._
 
 ###Instructions Specification###
 
 `instructions` is a set of markup instructions:
 
-* `crop`: Instructions to crop the image
+- `crop`: Instructions to crop the image
 
       * `from`: Top-left pixel coordinates of crop. This is an (`x`, `y`) tuple.
 
       * `size`: Pixel size of crop. This is a (`height`, `width`) tuple.
 
-* `draw`: An array of markup drawing instructions (described below)
+- `draw`: An array of markup drawing instructions (described below)
 
 ####Markup Drawing Instructions####
 
-* `circle`: Instructions to draw a circle
+- `circle`: Instructions to draw a circle
 
       * `color`: A color name (e.g. 'red')
 
@@ -47,7 +47,7 @@ The Builder JSON schema is made up of the following top elements:
 
       * `radius`: The pixel radius of the circle
 
-* `rectangle`: Instructions to draw a rectangle
+- `rectangle`: Instructions to draw a rectangle
 
       * `color`: A color name (e.g. 'red')
 
@@ -55,59 +55,11 @@ The Builder JSON schema is made up of the following top elements:
 
       * size: A (`height`, `width`) tuple of the size of the rectangle.
 
-## Sample JSON String ##
+## Sample JSON String
 
-`{
-  "dimensions": {
-    "width": 3260,
-    "height": 2445
-  },
-  "finalDimensions": {
-    "width": 2588,
-    "height": 1941
-  },
-  "instructions": {
-    "crop": {
-      "from": {
-        "x": 330,
-        "y": 330
-      },
-      "size": {
-        "width": 2588,
-        "height": 1941
-      }
-    },
-    "draw": [
-      {
-        "circle": {
-          "from": {
-            "x": 522,
-            "y": 505
-          },
-          "radius": 147,
-          "color": "red"
-        }
-      },
-      {
-        "rectangle": {
-          "from": {
-            "x": 1602,
-            "y": 605
-          },
-          "size": {
-            "width": 131,
-            "height": 131
-          },
-          "color": "black"
-        }
-      }
-    ]
-  },
-  "sourceFile": ".\/source.jpg",
-  "destinationFile": ".\/destination.jpg"
-}`
+`{ "dimensions": { "width": 3260, "height": 2445 }, "finalDimensions": { "width": 2588, "height": 1941 }, "instructions": { "crop": { "from": { "x": 330, "y": 330 }, "size": { "width": 2588, "height": 1941 } }, "draw": [ { "circle": { "from": { "x": 522, "y": 505 }, "radius": 147, "color": "red" } }, { "rectangle": { "from": { "x": 1602, "y": 605 }, "size": { "width": 131, "height": 131 }, "color": "black" } } ] }, "sourceFile": ".\/source.jpg", "destinationFile": ".\/destination.jpg" }`
 
-# Builder Markup String #
+# Builder Markup String
 
 `ImageMarkupCall` supports a semicolon-separated Markup string for more compact drawing instruction specification.
 
@@ -117,7 +69,7 @@ Example:
 
 `crop,330x330,2588x1941;circle,1921x466,70,black;rectangle,369x973,131x131,red;rectangle,1602x605,131x131,black`
 
-## Specification ##
+## Specification
 
 `crop,[x],[y],[width]x[height]`
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -57,6 +57,7 @@ The Builder JSON schema is made up of the following top elements:
 
 ## Sample JSON String ##
 
+<!-- prettier-ignore -->
 `{
   "dimensions": {
     "width": 3260,

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,45 +1,45 @@
-# Builder JSON
+# Builder JSON #
 
-## Introduction
+## Introduction ##
 
 The Builder JSON format provides instructions to Node Markup's `ImageMarkupBuilder` (or `ImageMarkupCall` if done from command line).
 
-## Specification
+## Specification ##
 
 The Builder JSON schema is made up of the following top elements:
 
-- `dimensions`: The original dimensions of the image/canvas. This is a (`height`, `width`) tuple.
-- `finalDimensions`: The final dimensions of the image/canvas. This is a (`height`, `width`) tuple.
-- `instructions`: A set of image modifcation instructions (described below).
+* `dimensions`: The original dimensions of the image/canvas. This is a (`height`, `width`) tuple.
+* `finalDimensions`: The final dimensions of the image/canvas. This is a (`height`, `width`) tuple.
+* `instructions`: A set of image modifcation instructions (described below).
 
-####_Node.js-specific elements_####
+####*Node.js-specific elements*####
 
-- `sourceFile`: The source JPEG to apply markup instructions to.
-- `destinationFile`: The destination JPEG to save to.
+* `sourceFile`: The source JPEG to apply markup instructions to.
+* `destinationFile`: The destination JPEG to save to.
 
-####_Frontend- or HTML-specific elements_####
+####*Frontend- or HTML-specific elements*####
 
-- `previewInstructions`: Instructions (described below) to support downsizing an image to fit in a smaller container.
+* `previewInstructions`: Instructions (described below) to support downsizing an image to fit in a smaller container.
 
       * `ratio`: The ratio of original size to preview size. For example, if the original image width is 1024px and the preview container size is 640px, `ratio = 1024 / 640 = 1.6`.
 
-_If `previewInstructions.ratio` is specified, give absolute pixel coordinates/sizes in `draw` instructions based on the preview size. They will be upscaled automatically._
+*If `previewInstructions.ratio` is specified, give absolute pixel coordinates/sizes in `draw` instructions based on the preview size. They will be upscaled automatically.*
 
 ###Instructions Specification###
 
 `instructions` is a set of markup instructions:
 
-- `crop`: Instructions to crop the image
+* `crop`: Instructions to crop the image
 
       * `from`: Top-left pixel coordinates of crop. This is an (`x`, `y`) tuple.
 
       * `size`: Pixel size of crop. This is a (`height`, `width`) tuple.
 
-- `draw`: An array of markup drawing instructions (described below)
+* `draw`: An array of markup drawing instructions (described below)
 
 ####Markup Drawing Instructions####
 
-- `circle`: Instructions to draw a circle
+* `circle`: Instructions to draw a circle
 
       * `color`: A color name (e.g. 'red')
 
@@ -47,7 +47,7 @@ _If `previewInstructions.ratio` is specified, give absolute pixel coordinates/si
 
       * `radius`: The pixel radius of the circle
 
-- `rectangle`: Instructions to draw a rectangle
+* `rectangle`: Instructions to draw a rectangle
 
       * `color`: A color name (e.g. 'red')
 
@@ -55,11 +55,59 @@ _If `previewInstructions.ratio` is specified, give absolute pixel coordinates/si
 
       * size: A (`height`, `width`) tuple of the size of the rectangle.
 
-## Sample JSON String
+## Sample JSON String ##
 
-`{ "dimensions": { "width": 3260, "height": 2445 }, "finalDimensions": { "width": 2588, "height": 1941 }, "instructions": { "crop": { "from": { "x": 330, "y": 330 }, "size": { "width": 2588, "height": 1941 } }, "draw": [ { "circle": { "from": { "x": 522, "y": 505 }, "radius": 147, "color": "red" } }, { "rectangle": { "from": { "x": 1602, "y": 605 }, "size": { "width": 131, "height": 131 }, "color": "black" } } ] }, "sourceFile": ".\/source.jpg", "destinationFile": ".\/destination.jpg" }`
+`{
+  "dimensions": {
+    "width": 3260,
+    "height": 2445
+  },
+  "finalDimensions": {
+    "width": 2588,
+    "height": 1941
+  },
+  "instructions": {
+    "crop": {
+      "from": {
+        "x": 330,
+        "y": 330
+      },
+      "size": {
+        "width": 2588,
+        "height": 1941
+      }
+    },
+    "draw": [
+      {
+        "circle": {
+          "from": {
+            "x": 522,
+            "y": 505
+          },
+          "radius": 147,
+          "color": "red"
+        }
+      },
+      {
+        "rectangle": {
+          "from": {
+            "x": 1602,
+            "y": 605
+          },
+          "size": {
+            "width": 131,
+            "height": 131
+          },
+          "color": "black"
+        }
+      }
+    ]
+  },
+  "sourceFile": ".\/source.jpg",
+  "destinationFile": ".\/destination.jpg"
+}`
 
-# Builder Markup String
+# Builder Markup String #
 
 `ImageMarkupCall` supports a semicolon-separated Markup string for more compact drawing instruction specification.
 
@@ -69,7 +117,7 @@ Example:
 
 `crop,330x330,2588x1941;circle,1921x466,70,black;rectangle,369x973,131x131,red;rectangle,1602x605,131x131,black`
 
-## Specification
+## Specification ##
 
 `crop,[x],[y],[width]x[height]`
 


### PR DESCRIPTION
Run prettier on the two toplevel Markdown files.

Note! I really dont like that prettier mashed up our example JSON. See: https://github.com/iFixit/node-markup/commit/f074b5b0b84d1906ad64c4445cbe06d1c53e9615

Ref: #44