### PR TITLE
Eslint fixes in `ImageMarkupBuilder`

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -558,7 +558,7 @@ function ImageMarkupBuilder(fabricCanvas) {
               y: Math.round(object.top / resizeRatio) + imageOffset.y,
             };
             var radius = Math.round(object.getRadiusX() / resizeRatio);
-            var color = translateRGBtoColorString(object.stroke);
+            var circleColor = translateRGBtoColorString(object.stroke);
 
             markupString +=
               "circle," +
@@ -568,7 +568,7 @@ function ImageMarkupBuilder(fabricCanvas) {
               "," +
               radius +
               "," +
-              color +
+              circleColor +
               ";";
             break;
           case "rectangle":
@@ -580,7 +580,7 @@ function ImageMarkupBuilder(fabricCanvas) {
               width: Math.round(object.width / resizeRatio),
               height: Math.round(object.height / resizeRatio),
             };
-            var color = translateRGBtoColorString(object.stroke);
+            var rectColor = translateRGBtoColorString(object.stroke);
 
             markupString +=
               "rectangle," +
@@ -592,7 +592,7 @@ function ImageMarkupBuilder(fabricCanvas) {
               "x" +
               size.height +
               "," +
-              color +
+              rectColor +
               ";";
             break;
           case "gap":

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -32,17 +32,11 @@ function ImageMarkupBuilder(fabricCanvas) {
   // Reference to the json object from processJSON
   var innerJSON;
 
-  // Expected group indexes
-  var borderIndex = 0;
-  var inlineIndex = 1;
-  var shapeIndex = 2;
-
   var imageOffset;
   var resizeRatio = 1;
   var finalWidth = 0;
   var markupObjects = [];
 
-  var whiteStroke = isNode ? 1 : 0.5;
   var strokeWidth = null;
   var crop = null;
 
@@ -109,9 +103,6 @@ function ImageMarkupBuilder(fabricCanvas) {
       applyMarkup(callback);
     } else {
       finalWidth = innerJSON.finalDimensions.width;
-      if (finalWidth <= 1800) {
-        whiteStroke = 1;
-      }
       if (isNode) {
         fabricCanvas.setBackgroundColor("#FFFFFF");
         require("fs").readFile(innerJSON.sourceFile, function (err, blob) {
@@ -500,8 +491,6 @@ function ImageMarkupBuilder(fabricCanvas) {
       cleanJSON(json);
 
       innerJSON = json;
-
-      var imagePath = innerJSON.sourceFile;
 
       crop = innerJSON.instructions.crop;
       imageOffset =

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -219,13 +219,9 @@ function ImageMarkupBuilder(fabricCanvas) {
    * Returns a strokeWidth calculated based on the dimensions of the canvas.
    */
   function getStrokeWidth(finalWidth) {
-    if (strokeWidth != null) {
-      var width = strokeWidth;
-    } else {
-      var width = Math.max(Math.round((finalWidth / 300) * 2), 4);
-    }
-
-    return width;
+    return strokeWidth != null
+      ? strokeWidth
+      : Math.max(Math.round((finalWidth / 300) * 2), 4);
   }
 
   function drawRectangle(shape) {

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -553,7 +553,7 @@ function ImageMarkupBuilder(fabricCanvas) {
 
         switch (object.shapeName) {
           case "circle":
-            var from = {
+            var circleFrom = {
               x: Math.round(object.left / resizeRatio) + imageOffset.x,
               y: Math.round(object.top / resizeRatio) + imageOffset.y,
             };
@@ -562,9 +562,9 @@ function ImageMarkupBuilder(fabricCanvas) {
 
             markupString +=
               "circle," +
-              from.x +
+              circleFrom.x +
               "x" +
-              from.y +
+              circleFrom.y +
               "," +
               radius +
               "," +
@@ -572,7 +572,7 @@ function ImageMarkupBuilder(fabricCanvas) {
               ";";
             break;
           case "rectangle":
-            var from = {
+            var rectFrom = {
               x: Math.round(object.left / resizeRatio) + imageOffset.x,
               y: Math.round(object.top / resizeRatio) + imageOffset.y,
             };
@@ -584,9 +584,9 @@ function ImageMarkupBuilder(fabricCanvas) {
 
             markupString +=
               "rectangle," +
-              from.x +
+              rectFrom.x +
               "x" +
-              from.y +
+              rectFrom.y +
               "," +
               size.width +
               "x" +


### PR DESCRIPTION
This finishes up the basic `eslint` bugs in repo! :tada: 

Mostly dropping unused variables, and "unique-ifying" existing in-scope redeclarations.

This commit in particular is a nice little cleanup: https://github.com/iFixit/node-markup/commit/3e8fe7596f754004f4aa8f45b5b2ae2ca82461d1

Ref #44 