### PR TITLE
Run Eslint in Lint Action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: 18
 
       - name: Prettier
-        run: npx prettier --check .
+        run: npx prettier@2.7.1 --check .
 
       - name: Eslint
-        run: npx eslint .
+        run: npx eslint@8.20.0 .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 18
 
-      - name: Pettier
+      - name: Prettier
         run: npx prettier --check .
 
       - name: Eslint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,8 @@ jobs:
         with:
           node-version: 18
 
-      - run: npx prettier --check .
+      - name: Pettier
+        run: npx prettier --check .
+
+      - name: Eslint
+        run: npx eslint .

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -138,7 +138,6 @@ function convertMarkupToJSON(callback, markup, infile, outfile) {
 
           var rectColor = args[3];
 
-          var rectangle;
           var rectangle = {
             from: rectFrom,
             size: rectSize,

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -138,6 +138,7 @@ function convertMarkupToJSON(callback, markup, infile, outfile) {
 
           var rectColor = args[3];
 
+          var rectangle;
           var rectangle = {
             from: rectFrom,
             size: rectSize,


### PR DESCRIPTION
While eslint can also do formatting and style checking, we're currently configuring and using eslint as a "static bug guard". Lets enforce formatting with prettier, and run eslint as well.

Closes #44 