### PR TITLE
Extract more utility helpers

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -1,7 +1,5 @@
-const { cleanJSON } = require("./src/utils");
+const { isNode, cleanJSON } = require("./src/utils");
 const Shapes = require("./shapes");
-
-var isNode = typeof window == "undefined";
 
 /**
  * Expects a Fabric.js Canvas

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -1,4 +1,5 @@
 const { cleanJSON } = require("./src/utils");
+const Shapes = require("./shapes");
 
 var isNode = typeof window == "undefined";
 
@@ -7,14 +8,6 @@ var isNode = typeof window == "undefined";
  */
 function ImageMarkupBuilder(fabricCanvas) {
   var Fabric = require("fabric").fabric;
-
-  var Shapes = {
-    Rectangle: require("./shapes/rectangle").klass,
-    Circle: require("./shapes/circle").klass,
-    Line: require("./shapes/line").klass,
-    Arrow: require("./shapes/arrow").klass,
-    Gap: require("./shapes/gap").klass,
-  };
 
   var colorValues = {
     red: "#C1280B",

--- a/shapes/index.js
+++ b/shapes/index.js
@@ -1,0 +1,9 @@
+const Shapes = {
+  Rectangle: require("./rectangle").klass,
+  Circle: require("./circle").klass,
+  Line: require("./line").klass,
+  Arrow: require("./arrow").klass,
+  Gap: require("./gap").klass,
+};
+
+module.exports = Shapes;

--- a/shapes/rectangle.js
+++ b/shapes/rectangle.js
@@ -1,5 +1,5 @@
+const { isNode } = require("../src/utils");
 var Fabric = require("fabric").fabric;
-var isNode = typeof window == "undefined";
 var mixin = require("../src/mixin");
 
 var Rectangle = Fabric.util.createClass(Fabric.Rect, {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const isNode = typeof window == "undefined";
+
 /**
  * Just like parseInt, but fixed to base-10
  */
@@ -45,6 +47,7 @@ function cleanJSON(json, context) {
 }
 
 module.exports = {
+  isNode,
   Int,
   cleanJSON,
 };


### PR DESCRIPTION
Extract our set of shapes into an index.js on the `shapes/` folder. This is nice to keep the shapes/mixins/Fabric-extensions as a single cohesive module, and out of the way of the main markup parsing.

Move the `isNode` global variable (declared in more than one place) into its own utility function. That way there is a single definition, that we are able to update independently of _many_ callsites.

cr_req 2
