### PR TITLE
Use `yargs` to improve interface to ImageMarkupCall

### DIFF
--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -34,10 +34,12 @@ var yargs = require("yargs")
       json: {
         describe: "String of JSON",
         string: true,
+        conflicts: "markup",
       },
       markup: {
         describe: "String of Markup",
         string: true,
+        conflicts: "json",
       },
       input: {
         describe: "Input image file to apply markup on",
@@ -88,7 +90,7 @@ function markupCommand(argv) {
 // the `command $0` default command, and resume the `check` for exactly one
 // command.
 function shimForFlags(argv) {
-   if ((argv.json && argv.markup) || (!argv.json && !argv.markup)) {
+   if (!argv.json && !argv.markup) {
       console.error(RequiredCommands);
       process.exit(-1);
    }

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -33,27 +33,35 @@ function processArgs() {
       usage(-1);
     }
 
-    var parsed = JSON.parse(argv.json);
-    processJSON(parsed);
+    jsonCommand(argv);
   } else if (argv.markup) {
     if (!argv.input || !argv.output) {
       console.error("Invalid usage. Input or output path missing.");
       usage(-1);
     }
 
-    const stroke = argv.stroke ? Int(argv.stroke) : null;
-
-    convertMarkupToJSON(
-      processJSON,
-      argv.markup,
-      argv.input,
-      argv.output,
-      stroke
-    );
+    markupCommand(argv);
   } else {
     console.error("Invalid uage.");
     usage(-1);
   }
+}
+
+function jsonCommand(argv) {
+  var parsed = JSON.parse(argv.json);
+  processJSON(parsed);
+}
+
+function markupCommand(argv) {
+  const stroke = argv.stroke ? Int(argv.stroke) : null;
+
+  convertMarkupToJSON(
+    processJSON,
+    argv.markup,
+    argv.input,
+    argv.output,
+    stroke
+  );
 }
 
 function processJSON(json) {

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -31,8 +31,7 @@ var yargs = require("yargs")
     },
     markupCommand
   )
-  // Lets use check once we have deprecated flag form commands
-  //.check((argv) => argv._.length === 1 || RequiredCommands)
+  .check((argv) => argv._.length <= 1 || RequiredCommands)
   .command(
     "$0",
     "Default command (shim for flags)",

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -78,6 +78,15 @@ function markupCommand(argv) {
   );
 }
 
+// Support flag form arguments (--json and --markup) for backwards CLI
+// compatibility. Yargs is not able to support commands with long flag format.
+// Even using aliases, the parser gets confused. Admittedly using options flags
+// as commands was misguided on the original interface. In order preserve the
+// existing behavior, we can continue to use flags, and this shim, to support
+// flag form commands (actually options, just on the default command).
+// Once we've deprecated these, we can drop this function, drop
+// the `command $0` default command, and resume the `check` for exactly one
+// command.
 function shimForFlags(argv) {
    if ((argv.json && argv.markup) || (!argv.json && !argv.markup)) {
       console.error(RequiredCommands);

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -41,7 +41,7 @@ var yargs = require("yargs")
         requiresArg: true,
         describe: "String of JSON",
         string: true,
-        conflicts: "markup",
+        conflicts: ["markup", "input", "output", "stroke"],
       },
       markup: {
         requiresArg: true,

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -28,6 +28,8 @@ var yargs = require("yargs")
     },
     markupCommand
   )
+  // Lets use check once we have deprecated flag form commands
+  //.check((argv) => argv._.length === 1 || RequiredCommands)
   .command("$0", "Default command (shim for flags)", {
       json: {
         describe: "String of JSON",
@@ -54,7 +56,6 @@ var yargs = require("yargs")
     describe: "Enable debug output.",
   })
   .alias("h", "help")
-  .check((argv) => argv._.length === 1 || RequiredCommands)
   .strict()
   .wrap(null);
 

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -28,6 +28,28 @@ var yargs = require("yargs")
     },
     markupCommand
   )
+  .command("$0", "Default command (shim for flags)", {
+      json: {
+        describe: "String of JSON",
+        string: true,
+      },
+      markup: {
+        describe: "String of Markup",
+        string: true,
+      },
+      input: {
+        describe: "Input image file to apply markup on",
+        string: true,
+      },
+      output: {
+        describe: "Output image file to write to",
+        string: true,
+      },
+      stroke: {
+        describe: "Stroke width to apply.",
+        number: true,
+      },
+   }, shimForFlags)
   .option("debug", {
     describe: "Enable debug output.",
   })
@@ -53,6 +75,27 @@ function markupCommand(argv) {
     argv.output,
     stroke
   );
+}
+
+function shimForFlags(argv) {
+   if ((argv.json && argv.markup) || (!argv.json && !argv.markup)) {
+      console.error(RequiredCommands);
+      process.exit(-1);
+   }
+
+   if (argv.json) {
+      argv.json_string = argv.json;
+      return jsonCommand(argv);
+   }
+
+   if (argv.markup) {
+      if (!argv.input || !argv.output) {
+         console.error("input and output options are required for markup");
+         process.exit(-1);
+      }
+      argv.markup_string = argv.markup
+      return markupCommand(argv);
+   }
 }
 
 function processJSON(json) {

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -30,7 +30,10 @@ var yargs = require("yargs")
   )
   // Lets use check once we have deprecated flag form commands
   //.check((argv) => argv._.length === 1 || RequiredCommands)
-  .command("$0", "Default command (shim for flags)", {
+  .command(
+    "$0",
+    "Default command (shim for flags)",
+    {
       json: {
         describe: "String of JSON",
         string: true,
@@ -53,7 +56,9 @@ var yargs = require("yargs")
         describe: "Stroke width to apply.",
         number: true,
       },
-   }, shimForFlags)
+    },
+    shimForFlags
+  )
   .option("debug", {
     describe: "Enable debug output.",
   })
@@ -90,24 +95,24 @@ function markupCommand(argv) {
 // the `command $0` default command, and resume the `check` for exactly one
 // command.
 function shimForFlags(argv) {
-   if (!argv.json && !argv.markup) {
-      console.error(RequiredCommands);
+  if (!argv.json && !argv.markup) {
+    console.error(RequiredCommands);
+    process.exit(-1);
+  }
+
+  if (argv.json) {
+    argv.json_string = argv.json;
+    return jsonCommand(argv);
+  }
+
+  if (argv.markup) {
+    if (!argv.input || !argv.output) {
+      console.error("input and output options are required for markup");
       process.exit(-1);
-   }
-
-   if (argv.json) {
-      argv.json_string = argv.json;
-      return jsonCommand(argv);
-   }
-
-   if (argv.markup) {
-      if (!argv.input || !argv.output) {
-         console.error("input and output options are required for markup");
-         process.exit(-1);
-      }
-      argv.markup_string = argv.markup
-      return markupCommand(argv);
-   }
+    }
+    argv.markup_string = argv.markup;
+    return markupCommand(argv);
+  }
 }
 
 function processJSON(json) {

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -48,6 +48,7 @@ var yargs = require("yargs")
         describe: "String of Markup",
         string: true,
         conflicts: "json",
+        implies: ["input", "output"],
       },
       input: {
         requiresArg: true,
@@ -114,10 +115,6 @@ function shimForFlags(argv) {
   }
 
   if (argv.markup) {
-    if (!argv.input || !argv.output) {
-      console.error("input and output options are required for markup");
-      process.exit(-1);
-    }
     argv.markup_string = argv.markup;
     return markupCommand(argv);
   }

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -12,16 +12,19 @@ var yargs = require("yargs")
     "Process markup string input",
     {
       input: {
+        requiresArg: true,
         demandOption: true,
         describe: "Input image file to apply markup on",
         string: true,
       },
       output: {
+        requiresArg: true,
         demandOption: true,
         describe: "Output image file to write to",
         string: true,
       },
       stroke: {
+        requiresArg: true,
         describe: "Stroke width to apply.",
         number: true,
       },
@@ -35,24 +38,29 @@ var yargs = require("yargs")
     "Default command (shim for flags)",
     {
       json: {
+        requiresArg: true,
         describe: "String of JSON",
         string: true,
         conflicts: "markup",
       },
       markup: {
+        requiresArg: true,
         describe: "String of Markup",
         string: true,
         conflicts: "json",
       },
       input: {
+        requiresArg: true,
         describe: "Input image file to apply markup on",
         string: true,
       },
       output: {
+        requiresArg: true,
         describe: "Output image file to write to",
         string: true,
       },
       stroke: {
+        requiresArg: true,
         describe: "Stroke width to apply.",
         number: true,
       },

--- a/run-tests.py
+++ b/run-tests.py
@@ -104,7 +104,7 @@ def runNode(sourceFilename, destinationFilename, markupFilename):
    markup = readMarkupFile(markupFilename).strip();
 
    cmd = ["bash", "node-markup.sh", "--input", sourceFilename, "--output",
-      destinationFilename, "--markup", markup, "--debug"];
+      destinationFilename, "markup", markup, "--debug"];
 
    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE);
    (out, err) = proc.communicate();


### PR DESCRIPTION
We've got `yargs` handy, but we were still doing many fiddly and manual
`usage` calls around argument validation. Lets push most of the config
and help docs into the `yargs` builder, and simplifiy down our `usage`
to `warnAndExit`.

Also, lets extract out most of the argv validation into it's own
function. This helps to simplify down main `processArgs`.

Note that this should not affect behaviour in any way.

Also note that this makes our `--help` output much nicer:
```sh
$ node ImageMarkupCall.js -h
Example Usage:
node ImageMarkupCall.js [help|-h] - Show this information
node ImageMarkupCall.js <command> [options]

Commands:
  ImageMarkupCall.js --json '[json_string]'
Process JSON input
  ImageMarkupCall.js --markup '[markup_string]' --input infile.jpg --output outfile.jpg  Process Markup string input

Options:
  --version        Show version number  [boolean]
  --json_string    JSON to apply
  --markup_string  Markup string to apply
  --input          Input image file to apply markup on
  --output         Output image file to write to
  --stroke         StrokeWidth to apply. May only be used with JSON input!
  --debug          Enable debug output.
  -h, --help       Show help  [boolean]
```

cr_req 2 so that I'm not just stamping my own work.
qa_req 0 None of this will go live immediately; we can test it when we update our submodule.