### PR TITLE
Refactor `convertMarkupToJSON` to Promises

### DIFF
--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -85,12 +85,11 @@ function markupCommand(argv) {
   const stroke = argv.stroke ? Int(argv.stroke) : null;
 
   convertMarkupToJSON(
-    processJSON,
     argv.markup_string,
     argv.input,
     argv.output,
     stroke
-  );
+  ).then(processJSON);
 }
 
 // Support flag form arguments (--json and --markup) for backwards CLI

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -84,12 +84,9 @@ function jsonCommand(argv) {
 function markupCommand(argv) {
   const stroke = argv.stroke ? Int(argv.stroke) : null;
 
-  convertMarkupToJSON(
-    argv.markup_string,
-    argv.input,
-    argv.output,
-    stroke
-  ).then(processJSON);
+  convertMarkupToJSON(argv.markup_string, argv.input, argv.output, stroke).then(
+    processJSON
+  );
 }
 
 // Support flag form arguments (--json and --markup) for backwards CLI

--- a/src/markup_to_json.js
+++ b/src/markup_to_json.js
@@ -1,6 +1,7 @@
 var { Int } = require("./utils");
 
-function convertMarkupToJSON(callback, markup, infile, outfile, stroke) {
+function convertMarkupToJSON(markup, infile, outfile, stroke) {
+  return new Promise((resolve) => {
   var json = {};
 
   var GM = require("gm");
@@ -128,7 +129,8 @@ function convertMarkupToJSON(callback, markup, infile, outfile, stroke) {
       json.instructions.strokeWidth = stroke;
     }
 
-    callback(json);
+    resolve(json);
+  });
   });
 }
 

--- a/src/markup_to_json.js
+++ b/src/markup_to_json.js
@@ -10,11 +10,11 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
 
       json["instructions"] = {};
 
-      const nonEmpty = instruction => instruction != "";
+      const nonEmpty = (instruction) => instruction != "";
       var instructions = markup.split(";").filter(nonEmpty);
 
       instructions.forEach((instruction) => {
-         JSONFromMarkup(instruction, json);
+        JSONFromMarkup(instruction, json);
       });
 
       json["sourceFile"] = infile;
@@ -30,112 +30,109 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
 }
 
 function JSONFromMarkup(instruction, json) {
-        var args = instruction.split(",");
-        var command = args[0];
-        switch (command) {
-          case "crop":
-            var cropPosition = args[1].split("x");
-            cropPosition[0] = Int(cropPosition[0]);
-            cropPosition[1] = Int(cropPosition[1]);
-            var cropFrom = {
-              x: cropPosition[0],
-              y: cropPosition[1],
-            };
+  var args = instruction.split(",");
+  var command = args[0];
+  switch (command) {
+    case "crop":
+      var cropPosition = args[1].split("x");
+      cropPosition[0] = Int(cropPosition[0]);
+      cropPosition[1] = Int(cropPosition[1]);
+      var cropFrom = {
+        x: cropPosition[0],
+        y: cropPosition[1],
+      };
 
-            var cropDimensions = args[2].split("x");
-            cropDimensions[0] = Int(cropDimensions[0]);
-            cropDimensions[1] = Int(cropDimensions[1]);
-            var cropSize = {
-              width: cropDimensions[0],
-              height: cropDimensions[1],
-            };
+      var cropDimensions = args[2].split("x");
+      cropDimensions[0] = Int(cropDimensions[0]);
+      cropDimensions[1] = Int(cropDimensions[1]);
+      var cropSize = {
+        width: cropDimensions[0],
+        height: cropDimensions[1],
+      };
 
-            var crop = {};
-            crop["from"] = cropFrom;
-            crop["size"] = cropSize;
+      var crop = {};
+      crop["from"] = cropFrom;
+      crop["size"] = cropSize;
 
-            json["instructions"]["crop"] = crop;
-            json["finalDimensions"] = crop["size"];
-            break;
-          case "circle":
-            if (!json["instructions"]["draw"])
-              json["instructions"]["draw"] = [];
+      json["instructions"]["crop"] = crop;
+      json["finalDimensions"] = crop["size"];
+      break;
+    case "circle":
+      if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
 
-            var circlePosition = args[1].split("x");
-            circlePosition[0] = Int(circlePosition[0]);
-            circlePosition[1] = Int(circlePosition[1]);
-            var circleFrom = {
-              x: circlePosition[0],
-              y: circlePosition[1],
-            };
+      var circlePosition = args[1].split("x");
+      circlePosition[0] = Int(circlePosition[0]);
+      circlePosition[1] = Int(circlePosition[1]);
+      var circleFrom = {
+        x: circlePosition[0],
+        y: circlePosition[1],
+      };
 
-            var radius = Int(args[2]);
-            var circleColor = args[3];
+      var radius = Int(args[2]);
+      var circleColor = args[3];
 
-            var circle = {};
-            circle["from"] = circleFrom;
-            circle["radius"] = radius;
-            circle["color"] = circleColor;
+      var circle = {};
+      circle["from"] = circleFrom;
+      circle["radius"] = radius;
+      circle["color"] = circleColor;
 
-            json["instructions"]["draw"].push({ circle: circle });
-            break;
-          case "rectangle":
-            if (!json["instructions"]["draw"])
-              json["instructions"]["draw"] = [];
+      json["instructions"]["draw"].push({ circle: circle });
+      break;
+    case "rectangle":
+      if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
 
-            var rectPosition = args[1].split("x");
-            rectPosition[0] = Int(rectPosition[0]);
-            rectPosition[1] = Int(rectPosition[1]);
-            var rectFrom = {
-              x: rectPosition[0],
-              y: rectPosition[1],
-            };
+      var rectPosition = args[1].split("x");
+      rectPosition[0] = Int(rectPosition[0]);
+      rectPosition[1] = Int(rectPosition[1]);
+      var rectFrom = {
+        x: rectPosition[0],
+        y: rectPosition[1],
+      };
 
-            var rectDimensions = args[2].split("x");
-            rectDimensions[0] = Int(rectDimensions[0]);
-            rectDimensions[1] = Int(rectDimensions[1]);
-            var rectSize = {
-              width: rectDimensions[0],
-              height: rectDimensions[1],
-            };
+      var rectDimensions = args[2].split("x");
+      rectDimensions[0] = Int(rectDimensions[0]);
+      rectDimensions[1] = Int(rectDimensions[1]);
+      var rectSize = {
+        width: rectDimensions[0],
+        height: rectDimensions[1],
+      };
 
-            var rectColor = args[3];
+      var rectColor = args[3];
 
-            var rectangle = {
-              from: rectFrom,
-              size: rectSize,
-              color: rectColor,
-            };
+      var rectangle = {
+        from: rectFrom,
+        size: rectSize,
+        color: rectColor,
+      };
 
-            json["instructions"]["draw"].push({ rectangle: rectangle });
-            break;
-          case "line":
-          case "arrow":
-          case "gap":
-            if (!json["instructions"]["draw"])
-              json["instructions"]["draw"] = [];
+      json["instructions"]["draw"].push({ rectangle: rectangle });
+      break;
+    case "line":
+    case "arrow":
+    case "gap":
+      if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
 
-            var p1 = args[1].split("x");
-            var p2 = args[2].split("x");
+      var p1 = args[1].split("x");
+      var p2 = args[2].split("x");
 
-            var line = {
-              from: {
-                x: Int(p1[0]),
-                y: Int(p1[1]),
-              },
-              to: {
-                x: Int(p2[0]),
-                y: Int(p2[1]),
-              },
-              color: args[3],
-            };
-            var gapInstruction = {};
-            gapInstruction[command] = line;
+      var line = {
+        from: {
+          x: Int(p1[0]),
+          y: Int(p1[1]),
+        },
+        to: {
+          x: Int(p2[0]),
+          y: Int(p2[1]),
+        },
+        color: args[3],
+      };
+      var gapInstruction = {};
+      gapInstruction[command] = line;
 
-            json["instructions"]["draw"].push(gapInstruction);
-            break;
-          default:
-        }
+      json["instructions"]["draw"].push(gapInstruction);
+      break;
+    default:
+  }
 }
 
 function GMGetSize(infile) {

--- a/src/markup_to_json.js
+++ b/src/markup_to_json.js
@@ -2,135 +2,138 @@ var { Int } = require("./utils");
 
 function convertMarkupToJSON(markup, infile, outfile, stroke) {
   return new Promise((resolve) => {
-  var json = {};
+    var json = {};
 
-  var GM = require("gm");
-  GM(infile).size(function (err, size) {
-    if (err) throw err;
+    var GM = require("gm");
+    GM(infile).size(function (err, size) {
+      if (err) throw err;
 
-    json["dimensions"] = size;
-    json["finalDimensions"] = size;
+      json["dimensions"] = size;
+      json["finalDimensions"] = size;
 
-    json["instructions"] = {};
+      json["instructions"] = {};
 
-    var instructions = markup.split(";");
-    for (var i = 0; i < instructions.length; ++i) {
-      if (instructions[i] == "") continue;
+      var instructions = markup.split(";");
+      for (var i = 0; i < instructions.length; ++i) {
+        if (instructions[i] == "") continue;
 
-      var args = instructions[i].split(",");
-      var command = args[0];
-      switch (command) {
-        case "crop":
-          var cropPosition = args[1].split("x");
-          cropPosition[0] = Int(cropPosition[0]);
-          cropPosition[1] = Int(cropPosition[1]);
-          var cropFrom = {
-            x: cropPosition[0],
-            y: cropPosition[1],
-          };
+        var args = instructions[i].split(",");
+        var command = args[0];
+        switch (command) {
+          case "crop":
+            var cropPosition = args[1].split("x");
+            cropPosition[0] = Int(cropPosition[0]);
+            cropPosition[1] = Int(cropPosition[1]);
+            var cropFrom = {
+              x: cropPosition[0],
+              y: cropPosition[1],
+            };
 
-          var cropDimensions = args[2].split("x");
-          cropDimensions[0] = Int(cropDimensions[0]);
-          cropDimensions[1] = Int(cropDimensions[1]);
-          var cropSize = {
-            width: cropDimensions[0],
-            height: cropDimensions[1],
-          };
+            var cropDimensions = args[2].split("x");
+            cropDimensions[0] = Int(cropDimensions[0]);
+            cropDimensions[1] = Int(cropDimensions[1]);
+            var cropSize = {
+              width: cropDimensions[0],
+              height: cropDimensions[1],
+            };
 
-          var crop = {};
-          crop["from"] = cropFrom;
-          crop["size"] = cropSize;
+            var crop = {};
+            crop["from"] = cropFrom;
+            crop["size"] = cropSize;
 
-          json["instructions"]["crop"] = crop;
-          json["finalDimensions"] = crop["size"];
-          break;
-        case "circle":
-          if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
+            json["instructions"]["crop"] = crop;
+            json["finalDimensions"] = crop["size"];
+            break;
+          case "circle":
+            if (!json["instructions"]["draw"])
+              json["instructions"]["draw"] = [];
 
-          var circlePosition = args[1].split("x");
-          circlePosition[0] = Int(circlePosition[0]);
-          circlePosition[1] = Int(circlePosition[1]);
-          var circleFrom = {
-            x: circlePosition[0],
-            y: circlePosition[1],
-          };
+            var circlePosition = args[1].split("x");
+            circlePosition[0] = Int(circlePosition[0]);
+            circlePosition[1] = Int(circlePosition[1]);
+            var circleFrom = {
+              x: circlePosition[0],
+              y: circlePosition[1],
+            };
 
-          var radius = Int(args[2]);
-          var circleColor = args[3];
+            var radius = Int(args[2]);
+            var circleColor = args[3];
 
-          var circle = {};
-          circle["from"] = circleFrom;
-          circle["radius"] = radius;
-          circle["color"] = circleColor;
+            var circle = {};
+            circle["from"] = circleFrom;
+            circle["radius"] = radius;
+            circle["color"] = circleColor;
 
-          json["instructions"]["draw"].push({ circle: circle });
-          break;
-        case "rectangle":
-          if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
+            json["instructions"]["draw"].push({ circle: circle });
+            break;
+          case "rectangle":
+            if (!json["instructions"]["draw"])
+              json["instructions"]["draw"] = [];
 
-          var rectPosition = args[1].split("x");
-          rectPosition[0] = Int(rectPosition[0]);
-          rectPosition[1] = Int(rectPosition[1]);
-          var rectFrom = {
-            x: rectPosition[0],
-            y: rectPosition[1],
-          };
+            var rectPosition = args[1].split("x");
+            rectPosition[0] = Int(rectPosition[0]);
+            rectPosition[1] = Int(rectPosition[1]);
+            var rectFrom = {
+              x: rectPosition[0],
+              y: rectPosition[1],
+            };
 
-          var rectDimensions = args[2].split("x");
-          rectDimensions[0] = Int(rectDimensions[0]);
-          rectDimensions[1] = Int(rectDimensions[1]);
-          var rectSize = {
-            width: rectDimensions[0],
-            height: rectDimensions[1],
-          };
+            var rectDimensions = args[2].split("x");
+            rectDimensions[0] = Int(rectDimensions[0]);
+            rectDimensions[1] = Int(rectDimensions[1]);
+            var rectSize = {
+              width: rectDimensions[0],
+              height: rectDimensions[1],
+            };
 
-          var rectColor = args[3];
+            var rectColor = args[3];
 
-          var rectangle = {
-            from: rectFrom,
-            size: rectSize,
-            color: rectColor,
-          };
+            var rectangle = {
+              from: rectFrom,
+              size: rectSize,
+              color: rectColor,
+            };
 
-          json["instructions"]["draw"].push({ rectangle: rectangle });
-          break;
-        case "line":
-        case "arrow":
-        case "gap":
-          if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
+            json["instructions"]["draw"].push({ rectangle: rectangle });
+            break;
+          case "line":
+          case "arrow":
+          case "gap":
+            if (!json["instructions"]["draw"])
+              json["instructions"]["draw"] = [];
 
-          var p1 = args[1].split("x");
-          var p2 = args[2].split("x");
+            var p1 = args[1].split("x");
+            var p2 = args[2].split("x");
 
-          var line = {
-            from: {
-              x: Int(p1[0]),
-              y: Int(p1[1]),
-            },
-            to: {
-              x: Int(p2[0]),
-              y: Int(p2[1]),
-            },
-            color: args[3],
-          };
-          var instruction = {};
-          instruction[command] = line;
+            var line = {
+              from: {
+                x: Int(p1[0]),
+                y: Int(p1[1]),
+              },
+              to: {
+                x: Int(p2[0]),
+                y: Int(p2[1]),
+              },
+              color: args[3],
+            };
+            var instruction = {};
+            instruction[command] = line;
 
-          json["instructions"]["draw"].push(instruction);
-          break;
-        default:
+            json["instructions"]["draw"].push(instruction);
+            break;
+          default:
+        }
       }
-    }
 
-    json["sourceFile"] = infile;
-    json["destinationFile"] = outfile;
+      json["sourceFile"] = infile;
+      json["destinationFile"] = outfile;
 
-    if (stroke != null) {
-      json.instructions.strokeWidth = stroke;
-    }
+      if (stroke != null) {
+        json.instructions.strokeWidth = stroke;
+      }
 
-    resolve(json);
-  });
+      resolve(json);
+    });
   });
 }
 

--- a/src/markup_to_json.js
+++ b/src/markup_to_json.js
@@ -11,10 +11,9 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
       json["instructions"] = {};
 
       var instructions = markup.split(";");
-      for (var i = 0; i < instructions.length; ++i) {
+      instructions.forEach((instruction) => {
         if (instructions[i] == "") continue;
-
-        var args = instructions[i].split(",");
+        var args = instruction.split(",");
         var command = args[0];
         switch (command) {
           case "crop":

--- a/src/markup_to_json.js
+++ b/src/markup_to_json.js
@@ -129,10 +129,10 @@ function JSONFromMarkup(instruction, json) {
               },
               color: args[3],
             };
-            var instruction = {};
-            instruction[command] = line;
+            var gapInstruction = {};
+            gapInstruction[command] = line;
 
-            json["instructions"]["draw"].push(instruction);
+            json["instructions"]["draw"].push(gapInstruction);
             break;
           default:
         }

--- a/src/markup_to_json.js
+++ b/src/markup_to_json.js
@@ -10,9 +10,10 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
 
       json["instructions"] = {};
 
-      var instructions = markup.split(";");
+      const nonEmpty = instruction => instruction != "";
+      var instructions = markup.split(";").filter(nonEmpty);
+
       instructions.forEach((instruction) => {
-        if (instructions[i] == "") continue;
         var args = instruction.split(",");
         var command = args[0];
         switch (command) {

--- a/src/markup_to_json.js
+++ b/src/markup_to_json.js
@@ -1,10 +1,9 @@
-var { Int } = require("./utils");
+const { Int } = require("./utils");
+const GM = require("gm");
 
 function convertMarkupToJSON(markup, infile, outfile, stroke) {
   return new Promise((resolve) => {
     var json = {};
-
-    var GM = require("gm");
     GM(infile).size(function (err, size) {
       if (err) throw err;
 

--- a/src/markup_to_json.js
+++ b/src/markup_to_json.js
@@ -14,6 +14,22 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
       var instructions = markup.split(";").filter(nonEmpty);
 
       instructions.forEach((instruction) => {
+         JSONFromMarkup(instruction, json);
+      });
+
+      json["sourceFile"] = infile;
+      json["destinationFile"] = outfile;
+
+      if (stroke != null) {
+        json.instructions.strokeWidth = stroke;
+      }
+
+      resolve(json);
+    });
+  });
+}
+
+function JSONFromMarkup(instruction, json) {
         var args = instruction.split(",");
         var command = args[0];
         switch (command) {
@@ -120,18 +136,6 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
             break;
           default:
         }
-      }
-
-      json["sourceFile"] = infile;
-      json["destinationFile"] = outfile;
-
-      if (stroke != null) {
-        json.instructions.strokeWidth = stroke;
-      }
-
-      resolve(json);
-    });
-  });
 }
 
 function GMGetSize(infile) {

--- a/src/markup_to_json.js
+++ b/src/markup_to_json.js
@@ -4,9 +4,7 @@ const GM = require("gm");
 function convertMarkupToJSON(markup, infile, outfile, stroke) {
   return new Promise((resolve) => {
     var json = {};
-    GM(infile).size(function (err, size) {
-      if (err) throw err;
-
+    GMGetSize(infile).then((size) => {
       json["dimensions"] = size;
       json["finalDimensions"] = size;
 
@@ -132,6 +130,17 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
       }
 
       resolve(json);
+    });
+  });
+}
+
+function GMGetSize(infile) {
+  return new Promise((resolve, reject) => {
+    GM(infile).size(function (err, size) {
+      if (err) {
+        reject(err);
+      }
+      resolve(size);
     });
   });
 }


### PR DESCRIPTION
The `GM('infile').size` call is async. I thought that was surprising. But that made writing a test for the converter prohibitively difficult. We're on Node v6 here, so we cannot use `async`/`await` either. Promises it is. They're boilerplatey for sure, but easy to simplify to async/await once we're on a later version of node.

The big structural changes here are:
- extracting a function for the `GM.size` call: https://github.com/iFixit/node-markup/commit/57d60803ff8c081dd245f2181e9c8aca040b931b
- Drastically simplifying the iteration logic over the split markup string (im pretty happy with how that refactor end up): 
   - https://github.com/iFixit/node-markup/commit/fde3d7e667576536b6dd6f0d5e09c32aedb886ff
   - https://github.com/iFixit/node-markup/commit/e5749413f01cb3764c12f10b1e1e1eec02104fba
   - The combined diff of these two is a little easier to understand: https://github.com/iFixit/node-markup/compare/e5749413f01cb3764c12f10b1e1e1eec02104fba..fde3d7e667576536b6dd6f0d5e09c32aedb886ff%5E 
- Pulling the instruction munging into a new function, `JSONFromMarkup`: https://github.com/iFixit/node-markup/commit/db928d75610583135eb27db6f87d2f68dc8a48b7

That last function isnt perfect, as we're still mutating the `json` variable. But we can work towards full immutability in future PRs. 

Note: view the diffs here ignoring whitespace. We're moving the indent level on the big switch block a few times, and have pulled out an indent by extracting it into a separate function. 