### PR TITLE
Misc fixes for Fabric.js upgrade

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -1,5 +1,6 @@
 const { isNode, cleanJSON } = require("./src/utils");
 const Shapes = require("./shapes");
+const path = require("path");
 
 /**
  * Expects a Fabric.js Canvas
@@ -96,31 +97,28 @@ function ImageMarkupBuilder(fabricCanvas) {
       finalWidth = innerJSON.finalDimensions.width;
       if (isNode) {
         fabricCanvas.setBackgroundColor("#FFFFFF");
-        require("fs").readFile(innerJSON.sourceFile, function (err, blob) {
-          if (err) throw err;
+        var dimensions = innerJSON.dimensions;
+        var img = {
+          width: dimensions.width,
+          height: dimensions.height,
+          originX: "left",
+          originY: "top",
+          src: "file://" + path.resolve(innerJSON.sourceFile),
+        };
 
-          var dimensions = innerJSON.dimensions;
-          var img = {
-            width: dimensions.width,
-            height: dimensions.height,
-            originX: "left",
-            originY: "top",
-            src: blob,
-          };
+        Fabric.Image.fromObject(img, function (fimg, err) {
+          if (!fimg || err) throw err;
+          var top = -imageOffset.y;
+          if (top % 1 != 0) {
+            top -= 0.5;
+          }
+          var left = -imageOffset.x;
+          if (left % 1 != 0) {
+            left -= 0.5;
+          }
 
-          Fabric.Image.fromObject(img, function (fimg) {
-            var top = -imageOffset.y;
-            if (top % 1 != 0) {
-              top -= 0.5;
-            }
-            var left = -imageOffset.x;
-            if (left % 1 != 0) {
-              left -= 0.5;
-            }
-
-            fabricCanvas.add(fimg.set("top", top).set("left", left));
-            applyMarkup(callback);
-          });
+          fabricCanvas.add(fimg.set("top", top).set("left", left));
+          applyMarkup(callback);
         });
       } else {
         throw new Error("Source files not supported on frontend");

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -119,10 +119,10 @@ function processJSON(json) {
   cleanJSON(json);
 
   var finalSize = json["finalDimensions"];
-  var canvas = Fabric.createCanvasForNode(
-    finalSize["width"],
-    finalSize["height"]
-  );
+  var canvas = new Fabric.StaticCanvas(null, {
+    width: finalSize["width"],
+    height: finalSize["height"],
+  });
   var builder = ImageMarkupBuilder(canvas);
 
   builder.processJSON(json, function () {

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -122,6 +122,7 @@ function processJSON(json) {
   var canvas = new Fabric.StaticCanvas(null, {
     width: finalSize["width"],
     height: finalSize["height"],
+    renderOnAddRemove: false,
   });
   var builder = ImageMarkupBuilder(canvas);
 

--- a/run-tests.py
+++ b/run-tests.py
@@ -106,8 +106,8 @@ def runNode(sourceFilename, destinationFilename, markupFilename):
     markup = readMarkupFile(markupFilename).strip()
 
     cmd = [
-        "bash",
-        "node-markup.sh",
+        "node",
+        "ImageMarkupCall.js",
         "--input",
         sourceFilename,
         "--output",


### PR DESCRIPTION
We were reading the sourceFile, and passing it to Fabric as a `blob`. Now, `fromObject` wants an URL. For local files, we can `resolve` a fully qualified `file://` URL to the source file for processing. Without passing a URL to Fabric.js v5.2.1, our tests crash hard and fast. This gets us much further through tests. See: https://github.com/iFixit/node-markup/commit/ee1c72a3c4b39fbad87d2bba88e51c3ddc4162d4

Next, we need to update our call to `createCanvasForNode`. That's gone, and does not work. The new API involves the `Fabric.Canvas` and `Fabric.StaticCanvas` classes. See: https://github.com/iFixit/node-markup/commit/7208098879aa40fa4c43dbe33b4ec9b963320f68

Lastly, with the previous fixes in place, we were seeing failures around `requestAnimationFrame`. Of course, this API is not available running on Node. We can avoid this problem by disabling automatic re-renders when calling `add` and `remove`. See: https://github.com/iFixit/node-markup/commit/e2acf1dc4f3e9d0deb75f6114fb7896f28c6cd78

### CR Note
View the diff here without whitespace changes for a much easier CR.

### Relevant docs links:
- [Docs link on breaking changes](http://fabricjs.com/v2-breaking-changes#image)
- [`Canvas` class docs](http://fabricjs.com/docs/fabric.Canvas.html)

CC @andyg0808 