### PR TITLE
Improve markup parsing

### DIFF
--- a/src/markup_to_json.test.js
+++ b/src/markup_to_json.test.js
@@ -30,3 +30,23 @@ describe("markup_to_jsonJSON", () => {
     });
   });
 });
+
+const newConvertMarkupToJSON = require("./new_markup_to_json");
+
+describe("New Markup parser `newConvertMarkupToJSON`", () => {
+  test("converts to expected JSON", async () => {
+    TestCases.forEach(async (testcase) => {
+      const testMarkup = fs.readFileSync(`./test/${testcase}.markup`, "utf8");
+      const expectedJSON = JSON.parse(
+        fs.readFileSync(`./test/${testcase}.json`, "utf8")
+      );
+      const testJSON = await newConvertMarkupToJSON(
+        testMarkup,
+        `./test/${testcase}.source.jpg`,
+        "./literally.anywhere"
+      );
+
+      expect(testJSON).toEqual(expectedJSON);
+    });
+  });
+});

--- a/src/markup_to_json.test.js
+++ b/src/markup_to_json.test.js
@@ -2,48 +2,31 @@ const { describe, expect, test } = require("@jest/globals");
 
 const fs = require("fs");
 
-const convertMarkupToJSON = require("./markup_to_json");
+const TestCases = [
+  "000066",
+  "00CC00",
+  "66CCFF",
+  "9900CC",
+  "993333",
+  "lines",
+  "simple-lines",
+];
 
-const expectedJSON = {
-  dimensions: { width: 1200, height: 900 },
-  finalDimensions: { width: 1032, height: 774 },
-  instructions: {
-    crop: {
-      from: { x: 168, y: 71 },
-      size: { width: 1032, height: 774 },
-    },
-    draw: [
-      { circle: { from: { x: 548, y: 671 }, radius: 21, color: "yellow" } },
-      {
-        rectangle: {
-          from: { x: 287, y: 484 },
-          size: { width: 28, height: 28 },
-          color: "blue",
-        },
-      },
-      { circle: { from: { x: 980, y: 467 }, radius: 113, color: "red" } },
-      {
-        rectangle: {
-          from: { x: 196, y: 200 },
-          size: { width: 404, height: 28 },
-          color: "black",
-        },
-      },
-    ],
-  },
-  sourceFile: "./test/993333.source.jpg",
-  destinationFile: "./literally.anywhere",
-};
+const convertMarkupToJSON = require("./markup_to_json");
 
 describe("markup_to_jsonJSON", () => {
   test("Markup converts to expected JSON", async () => {
-    const testMarkup = fs.readFileSync("./test/993333.markup", "utf8");
-    const testJSON = await convertMarkupToJSON(
-      testMarkup,
-      "./test/993333.source.jpg",
-      "./literally.anywhere"
-    );
-
-    expect(testJSON).toEqual(expectedJSON);
+    TestCases.forEach(async (testcase) => {
+      const testMarkup = fs.readFileSync(`./test/${testcase}.markup`, "utf8");
+      const expectedJSON = JSON.parse(
+        fs.readFileSync(`./test/${testcase}.json`, "utf8")
+      );
+      const testJSON = await convertMarkupToJSON(
+        testMarkup,
+        `./test/${testcase}.source.jpg`,
+        "./literally.anywhere"
+      );
+      expect(testJSON).toEqual(expectedJSON);
+    });
   });
 });

--- a/src/markup_to_json.test.js
+++ b/src/markup_to_json.test.js
@@ -3,19 +3,19 @@ const { describe, expect, test } = require("@jest/globals");
 const fs = require("fs");
 
 const TestCases = [
-  "000066",
-  "00CC00",
-  "66CCFF",
-  "9900CC",
-  "993333",
-  "lines",
-  "simple-lines",
+  ["000066"],
+  ["00CC00"],
+  ["66CCFF"],
+  ["9900CC"],
+  ["993333"],
+  ["lines"],
+  ["simple-lines"],
 ];
 
 const convertMarkupToJSON = require("./markup_to_json");
 
 describe("convertMarkupToJSON", () => {
-  test("converts markup to expected JSON", async () => {
+  test.each(TestCases)("converts markup to expected JSON", async () => {
     TestCases.forEach(async (testcase) => {
       const testMarkup = fs.readFileSync(`./test/${testcase}.markup`, "utf8");
       const expectedJSON = JSON.parse(
@@ -34,7 +34,7 @@ describe("convertMarkupToJSON", () => {
 const newConvertMarkupToJSON = require("./new_markup_to_json");
 
 describe("New Markup parser `newConvertMarkupToJSON`", () => {
-  test("converts to expected JSON", async () => {
+  test.each(TestCases)("converts to expected JSON", async () => {
     TestCases.forEach(async (testcase) => {
       const testMarkup = fs.readFileSync(`./test/${testcase}.markup`, "utf8");
       const expectedJSON = JSON.parse(

--- a/src/markup_to_json.test.js
+++ b/src/markup_to_json.test.js
@@ -15,38 +15,34 @@ const TestCases = [
 const convertMarkupToJSON = require("./markup_to_json");
 
 describe("convertMarkupToJSON", () => {
-  test.each(TestCases)("converts markup to expected JSON", async () => {
-    TestCases.forEach(async (testcase) => {
-      const testMarkup = fs.readFileSync(`./test/${testcase}.markup`, "utf8");
-      const expectedJSON = JSON.parse(
-        fs.readFileSync(`./test/${testcase}.json`, "utf8")
-      );
-      const testJSON = await convertMarkupToJSON(
-        testMarkup,
-        `./test/${testcase}.source.jpg`,
-        "./literally.anywhere"
-      );
-      expect(testJSON).toEqual(expectedJSON);
-    });
+  test.each(TestCases)("converts markup to expected JSON", async (testcase) => {
+    const testMarkup = fs.readFileSync(`./test/${testcase}.markup`, "utf8");
+    const expectedJSON = JSON.parse(
+      fs.readFileSync(`./test/${testcase}.json`, "utf8")
+    );
+    const testJSON = await convertMarkupToJSON(
+      testMarkup,
+      `./test/${testcase}.source.jpg`,
+      "./literally.anywhere"
+    );
+    expect(testJSON).toEqual(expectedJSON);
   });
 });
 
 const newConvertMarkupToJSON = require("./new_markup_to_json");
 
 describe("New Markup parser `newConvertMarkupToJSON`", () => {
-  test.each(TestCases)("converts to expected JSON", async () => {
-    TestCases.forEach(async (testcase) => {
-      const testMarkup = fs.readFileSync(`./test/${testcase}.markup`, "utf8");
-      const expectedJSON = JSON.parse(
-        fs.readFileSync(`./test/${testcase}.json`, "utf8")
-      );
-      const testJSON = await newConvertMarkupToJSON(
-        testMarkup,
-        `./test/${testcase}.source.jpg`,
-        "./literally.anywhere"
-      );
+  test.each(TestCases)("converts to expected JSON", async (testcase) => {
+    const testMarkup = fs.readFileSync(`./test/${testcase}.markup`, "utf8");
+    const expectedJSON = JSON.parse(
+      fs.readFileSync(`./test/${testcase}.json`, "utf8")
+    );
+    const testJSON = await newConvertMarkupToJSON(
+      testMarkup,
+      `./test/${testcase}.source.jpg`,
+      "./literally.anywhere"
+    );
 
-      expect(testJSON).toEqual(expectedJSON);
-    });
+    expect(testJSON).toEqual(expectedJSON);
   });
 });

--- a/src/markup_to_json.test.js
+++ b/src/markup_to_json.test.js
@@ -14,8 +14,8 @@ const TestCases = [
 
 const convertMarkupToJSON = require("./markup_to_json");
 
-describe("markup_to_jsonJSON", () => {
-  test("Markup converts to expected JSON", async () => {
+describe("convertMarkupToJSON", () => {
+  test("converts markup to expected JSON", async () => {
     TestCases.forEach(async (testcase) => {
       const testMarkup = fs.readFileSync(`./test/${testcase}.markup`, "utf8");
       const expectedJSON = JSON.parse(

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -1,5 +1,8 @@
+const util = require('util');
 const { Int } = require("./utils");
 const GM = require("gm");
+
+GM.prototype.sizeAsync = util.promisify(GM.prototype.size);
 
 const pos = (x, y) => ({ x: Int(x), y: Int(y) });
 const dim = (x, y) => ({ width: Int(x), height: Int(y) });
@@ -55,7 +58,7 @@ const MarkupParser = {
 };
 
 function convertMarkupToJSON(markup, infile, outfile, stroke) {
-  return GMGetSize(infile).then((size) => {
+  return GM(infile).sizeAsync().then((size) => {
     const json = {
       sourceFile: infile,
       destinationFile: outfile,
@@ -102,17 +105,6 @@ function parseInstruction(instruction) {
     }
   }
   throw `Could not parse markup instruction: '${instruction}'`;
-}
-
-function GMGetSize(infile) {
-  return new Promise((resolve, reject) => {
-    GM(infile).size(function (err, size) {
-      if (err) {
-        reject(err);
-      }
-      resolve(size);
-    });
-  });
 }
 
 module.exports = convertMarkupToJSON;

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -1,0 +1,149 @@
+const { Int } = require("./utils");
+const GM = require("gm");
+
+function convertMarkupToJSON(markup, infile, outfile, stroke) {
+  return new Promise((resolve) => {
+    var json = {};
+    GMGetSize(infile).then((size) => {
+      json["dimensions"] = size;
+      json["finalDimensions"] = size;
+
+      json["instructions"] = {};
+
+      const nonEmpty = (instruction) => instruction != "";
+      var instructions = markup.split(";").filter(nonEmpty);
+
+      instructions.forEach((instruction) => {
+        JSONFromMarkup(instruction, json);
+      });
+
+      json["sourceFile"] = infile;
+      json["destinationFile"] = outfile;
+
+      if (stroke != null) {
+        json.instructions.strokeWidth = stroke;
+      }
+
+      resolve(json);
+    });
+  });
+}
+
+function JSONFromMarkup(instruction, json) {
+  var args = instruction.split(",");
+  var command = args[0];
+  switch (command) {
+    case "crop":
+      var cropPosition = args[1].split("x");
+      cropPosition[0] = Int(cropPosition[0]);
+      cropPosition[1] = Int(cropPosition[1]);
+      var cropFrom = {
+        x: cropPosition[0],
+        y: cropPosition[1],
+      };
+
+      var cropDimensions = args[2].split("x");
+      cropDimensions[0] = Int(cropDimensions[0]);
+      cropDimensions[1] = Int(cropDimensions[1]);
+      var cropSize = {
+        width: cropDimensions[0],
+        height: cropDimensions[1],
+      };
+
+      var crop = {};
+      crop["from"] = cropFrom;
+      crop["size"] = cropSize;
+
+      json["instructions"]["crop"] = crop;
+      json["finalDimensions"] = crop["size"];
+      break;
+    case "circle":
+      if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
+
+      var circlePosition = args[1].split("x");
+      circlePosition[0] = Int(circlePosition[0]);
+      circlePosition[1] = Int(circlePosition[1]);
+      var circleFrom = {
+        x: circlePosition[0],
+        y: circlePosition[1],
+      };
+
+      var radius = Int(args[2]);
+      var circleColor = args[3];
+
+      var circle = {};
+      circle["from"] = circleFrom;
+      circle["radius"] = radius;
+      circle["color"] = circleColor;
+
+      json["instructions"]["draw"].push({ circle: circle });
+      break;
+    case "rectangle":
+      if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
+
+      var rectPosition = args[1].split("x");
+      rectPosition[0] = Int(rectPosition[0]);
+      rectPosition[1] = Int(rectPosition[1]);
+      var rectFrom = {
+        x: rectPosition[0],
+        y: rectPosition[1],
+      };
+
+      var rectDimensions = args[2].split("x");
+      rectDimensions[0] = Int(rectDimensions[0]);
+      rectDimensions[1] = Int(rectDimensions[1]);
+      var rectSize = {
+        width: rectDimensions[0],
+        height: rectDimensions[1],
+      };
+
+      var rectColor = args[3];
+
+      var rectangle = {
+        from: rectFrom,
+        size: rectSize,
+        color: rectColor,
+      };
+
+      json["instructions"]["draw"].push({ rectangle: rectangle });
+      break;
+    case "line":
+    case "arrow":
+    case "gap":
+      if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
+
+      var p1 = args[1].split("x");
+      var p2 = args[2].split("x");
+
+      var line = {
+        from: {
+          x: Int(p1[0]),
+          y: Int(p1[1]),
+        },
+        to: {
+          x: Int(p2[0]),
+          y: Int(p2[1]),
+        },
+        color: args[3],
+      };
+      var gapInstruction = {};
+      gapInstruction[command] = line;
+
+      json["instructions"]["draw"].push(gapInstruction);
+      break;
+    default:
+  }
+}
+
+function GMGetSize(infile) {
+  return new Promise((resolve, reject) => {
+    GM(infile).size(function (err, size) {
+      if (err) {
+        reject(err);
+      }
+      resolve(size);
+    });
+  });
+}
+
+module.exports = convertMarkupToJSON;

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -55,8 +55,7 @@ const MarkupParser = {
 };
 
 function convertMarkupToJSON(markup, infile, outfile, stroke) {
-  return new Promise((resolve) => {
-    GMGetSize(infile).then((size) => {
+    return GMGetSize(infile).then((size) => {
       const json = {
         sourceFile: infile,
         destinationFile: outfile,
@@ -91,8 +90,7 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
         json.instructions.strokeWidth = stroke;
       }
 
-      resolve(json);
-    });
+      return json;
   });
 }
 

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -3,10 +3,11 @@ const GM = require("gm");
 
 const pos = (x, y) => ({ x: Int(x), y: Int(y) });
 const dim = (x, y) => ({ width: Int(x), height: Int(y) });
+const color = '()'
 
 const MarkupParser = {
   crop: {
-    regex: /crop,(\d+)x(\d+),(\d+)x(\d+)/,
+    regex: new RegExp(`crop,(\\d+)x(\\d+),(\\d+)x(\\d+)`),
     t: (m) => ({
       block: "crop",
       instruction: {
@@ -16,7 +17,7 @@ const MarkupParser = {
     }),
   },
   circle: {
-    regex: /circle,(\d+)x(\d+),(\d+),(\w+)/,
+    regex: new RegExp(`circle,(\\d+)x(\\d+),(\\d+),(\\w+)`),
     t: (m) => ({
       block: "draw",
       id: "circle",
@@ -28,7 +29,7 @@ const MarkupParser = {
     }),
   },
   rectangle: {
-    regex: /rectangle,(\d+)x(\d+),(\d+)x(\d+),(\w+)/,
+    regex: new RegExp(`rectangle,(\\d+)x(\\d+),(\\d+)x(\\d+),(\\w+)`),
     t: (m) => ({
       block: "draw",
       id: "rectangle",
@@ -40,7 +41,7 @@ const MarkupParser = {
     }),
   },
   line: {
-    regex: /(line|arrow|gap),(\d+)x(\d+),(\d+)x(\d+),(\w+)/,
+    regex: new RegExp(`(line|arrow|gap),(\\d+)x(\\d+),(\\d+)x(\\d+),(\\w+)`),
     t: (m) => ({
       block: "draw",
       id: m[1],

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -68,7 +68,18 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
         .filter((x) => x);
 
       instructions.forEach((instruction) => {
-        JSONFromMarkup(instruction, json);
+        const result = parseInstruction(instruction);
+        if (result.block === "crop") {
+          json["instructions"]["crop"] = result.instruction;
+          json["finalDimensions"] = result.instruction["size"];
+        }
+        if (result.block === "draw") {
+          if (!json["instructions"]["draw"]) {
+            json["instructions"]["draw"] = [];
+          }
+          const drawCommand = { [result.id]: result.instruction };
+          json["instructions"]["draw"].push(drawCommand);
+        }
       });
 
       json["sourceFile"] = infile;

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -83,110 +83,14 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
   });
 }
 
-function JSONFromMarkup(instruction, json) {
-  var args = instruction.split(",");
-  var command = args[0];
-  switch (command) {
-    case "crop":
-      var cropPosition = args[1].split("x");
-      cropPosition[0] = Int(cropPosition[0]);
-      cropPosition[1] = Int(cropPosition[1]);
-      var cropFrom = {
-        x: cropPosition[0],
-        y: cropPosition[1],
-      };
-
-      var cropDimensions = args[2].split("x");
-      cropDimensions[0] = Int(cropDimensions[0]);
-      cropDimensions[1] = Int(cropDimensions[1]);
-      var cropSize = {
-        width: cropDimensions[0],
-        height: cropDimensions[1],
-      };
-
-      var crop = {};
-      crop["from"] = cropFrom;
-      crop["size"] = cropSize;
-
-      json["instructions"]["crop"] = crop;
-      json["finalDimensions"] = crop["size"];
-      break;
-    case "circle":
-      if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
-
-      var circlePosition = args[1].split("x");
-      circlePosition[0] = Int(circlePosition[0]);
-      circlePosition[1] = Int(circlePosition[1]);
-      var circleFrom = {
-        x: circlePosition[0],
-        y: circlePosition[1],
-      };
-
-      var radius = Int(args[2]);
-      var circleColor = args[3];
-
-      var circle = {};
-      circle["from"] = circleFrom;
-      circle["radius"] = radius;
-      circle["color"] = circleColor;
-
-      json["instructions"]["draw"].push({ circle: circle });
-      break;
-    case "rectangle":
-      if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
-
-      var rectPosition = args[1].split("x");
-      rectPosition[0] = Int(rectPosition[0]);
-      rectPosition[1] = Int(rectPosition[1]);
-      var rectFrom = {
-        x: rectPosition[0],
-        y: rectPosition[1],
-      };
-
-      var rectDimensions = args[2].split("x");
-      rectDimensions[0] = Int(rectDimensions[0]);
-      rectDimensions[1] = Int(rectDimensions[1]);
-      var rectSize = {
-        width: rectDimensions[0],
-        height: rectDimensions[1],
-      };
-
-      var rectColor = args[3];
-
-      var rectangle = {
-        from: rectFrom,
-        size: rectSize,
-        color: rectColor,
-      };
-
-      json["instructions"]["draw"].push({ rectangle: rectangle });
-      break;
-    case "line":
-    case "arrow":
-    case "gap":
-      if (!json["instructions"]["draw"]) json["instructions"]["draw"] = [];
-
-      var p1 = args[1].split("x");
-      var p2 = args[2].split("x");
-
-      var line = {
-        from: {
-          x: Int(p1[0]),
-          y: Int(p1[1]),
-        },
-        to: {
-          x: Int(p2[0]),
-          y: Int(p2[1]),
-        },
-        color: args[3],
-      };
-      var gapInstruction = {};
-      gapInstruction[command] = line;
-
-      json["instructions"]["draw"].push(gapInstruction);
-      break;
-    default:
+function parseInstruction(instruction) {
+  for (const { regex, t } of Object.values(MarkupParser)) {
+    const match = regex.exec(instruction);
+    if (match) {
+      return t(match);
+    }
   }
+  throw `Could not parse markup instruction: '${instruction}'`;
 }
 
 function GMGetSize(infile) {

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -56,12 +56,16 @@ const MarkupParser = {
 
 function convertMarkupToJSON(markup, infile, outfile, stroke) {
   return new Promise((resolve) => {
-    var json = {};
     GMGetSize(infile).then((size) => {
-      json["dimensions"] = size;
-      json["finalDimensions"] = size;
+      const json = {
+        sourceFile: infile,
+        destinationFile: outfile,
 
-      json["instructions"] = {};
+        dimensions: size,
+        finalDimensions: size,
+
+        instructions: {},
+      };
 
       var instructions = markup
         .trim()
@@ -82,9 +86,6 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
           json["instructions"]["draw"].push(drawCommand);
         }
       });
-
-      json["sourceFile"] = infile;
-      json["destinationFile"] = outfile;
 
       if (stroke != null) {
         json.instructions.strokeWidth = stroke;

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -67,7 +67,7 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
         instructions: {},
       };
 
-      var instructions = markup
+      const instructions = markup
         .trim()
         .split(";")
         .filter((x) => x);

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -55,42 +55,42 @@ const MarkupParser = {
 };
 
 function convertMarkupToJSON(markup, infile, outfile, stroke) {
-    return GMGetSize(infile).then((size) => {
-      const json = {
-        sourceFile: infile,
-        destinationFile: outfile,
+  return GMGetSize(infile).then((size) => {
+    const json = {
+      sourceFile: infile,
+      destinationFile: outfile,
 
-        dimensions: size,
-        finalDimensions: size,
+      dimensions: size,
+      finalDimensions: size,
 
-        instructions: {},
-      };
+      instructions: {},
+    };
 
-      const instructions = markup
-        .trim()
-        .split(";")
-        .filter((x) => x);
+    const instructions = markup
+      .trim()
+      .split(";")
+      .filter((x) => x);
 
-      instructions.forEach((instruction) => {
-        const result = parseInstruction(instruction);
-        if (result.block === "crop") {
-          json["instructions"]["crop"] = result.instruction;
-          json["finalDimensions"] = result.instruction["size"];
-        }
-        if (result.block === "draw") {
-          if (!json["instructions"]["draw"]) {
-            json["instructions"]["draw"] = [];
-          }
-          const drawCommand = { [result.id]: result.instruction };
-          json["instructions"]["draw"].push(drawCommand);
-        }
-      });
-
-      if (stroke != null) {
-        json.instructions.strokeWidth = stroke;
+    instructions.forEach((instruction) => {
+      const result = parseInstruction(instruction);
+      if (result.block === "crop") {
+        json["instructions"]["crop"] = result.instruction;
+        json["finalDimensions"] = result.instruction["size"];
       }
+      if (result.block === "draw") {
+        if (!json["instructions"]["draw"]) {
+          json["instructions"]["draw"] = [];
+        }
+        const drawCommand = { [result.id]: result.instruction };
+        json["instructions"]["draw"].push(drawCommand);
+      }
+    });
 
-      return json;
+    if (stroke != null) {
+      json.instructions.strokeWidth = stroke;
+    }
+
+    return json;
   });
 }
 

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -3,7 +3,7 @@ const GM = require("gm");
 
 const pos = (x, y) => ({ x: Int(x), y: Int(y) });
 const dim = (x, y) => ({ width: Int(x), height: Int(y) });
-const color = '()'
+const color = "(black|red|orange|yellow|green|blue|indigo|violet)";
 
 const MarkupParser = {
   crop: {
@@ -17,7 +17,7 @@ const MarkupParser = {
     }),
   },
   circle: {
-    regex: new RegExp(`circle,(\\d+)x(\\d+),(\\d+),(\\w+)`),
+    regex: new RegExp(`circle,(\\d+)x(\\d+),(\\d+),${color}`),
     t: (m) => ({
       block: "draw",
       id: "circle",
@@ -29,7 +29,7 @@ const MarkupParser = {
     }),
   },
   rectangle: {
-    regex: new RegExp(`rectangle,(\\d+)x(\\d+),(\\d+)x(\\d+),(\\w+)`),
+    regex: new RegExp(`rectangle,(\\d+)x(\\d+),(\\d+)x(\\d+),${color}`),
     t: (m) => ({
       block: "draw",
       id: "rectangle",
@@ -41,7 +41,7 @@ const MarkupParser = {
     }),
   },
   line: {
-    regex: new RegExp(`(line|arrow|gap),(\\d+)x(\\d+),(\\d+)x(\\d+),(\\w+)`),
+    regex: new RegExp(`(line|arrow|gap),(\\d+)x(\\d+),(\\d+)x(\\d+),${color}`),
     t: (m) => ({
       block: "draw",
       id: m[1],

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -1,6 +1,58 @@
 const { Int } = require("./utils");
 const GM = require("gm");
 
+const pos = (x, y) => ({ x: Int(x), y: Int(y) });
+const dim = (x, y) => ({ width: Int(x), height: Int(y) });
+
+const MarkupParser = {
+  crop: {
+    regex: /crop,(\d+)x(\d+),(\d+)x(\d+)/,
+    t: (m) => ({
+      block: "crop",
+      instruction: {
+        from: pos(m[1], m[2]),
+        size: dim(m[3], m[4]),
+      },
+    }),
+  },
+  circle: {
+    regex: /circle,(\d+)x(\d+),(\d+),(\w+)/,
+    t: (m) => ({
+      block: "draw",
+      id: "circle",
+      instruction: {
+        from: pos(m[1], m[2]),
+        radius: Int(m[3]),
+        color: m[4],
+      },
+    }),
+  },
+  rectangle: {
+    regex: /rectangle,(\d+)x(\d+),(\d+)x(\d+),(\w+)/,
+    t: (m) => ({
+      block: "draw",
+      id: "rectangle",
+      instruction: {
+        from: pos(m[1], m[2]),
+        size: dim(m[3], m[4]),
+        color: m[5],
+      },
+    }),
+  },
+  line: {
+    regex: /(line|arrow|gap),(\d+)x(\d+),(\d+)x(\d+),(\w+)/,
+    t: (m) => ({
+      block: "draw",
+      id: m[1],
+      instruction: {
+        from: pos(m[2], m[3]),
+        to: pos(m[4], m[5]),
+        color: m[6],
+      },
+    }),
+  },
+};
+
 function convertMarkupToJSON(markup, infile, outfile, stroke) {
   return new Promise((resolve) => {
     var json = {};

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -99,7 +99,7 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
 function parseInstruction(instruction) {
   for (const { regex, t } of Object.values(MarkupParser)) {
     const match = regex.exec(instruction);
-    if (match) {
+    if (match && match[0] === instruction) {
       return t(match);
     }
   }

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -1,4 +1,4 @@
-const util = require('util');
+const util = require("util");
 const { Int } = require("./utils");
 const GM = require("gm");
 
@@ -58,43 +58,45 @@ const MarkupParser = {
 };
 
 function convertMarkupToJSON(markup, infile, outfile, stroke) {
-  return GM(infile).sizeAsync().then((size) => {
-    const json = {
-      sourceFile: infile,
-      destinationFile: outfile,
+  return GM(infile)
+    .sizeAsync()
+    .then((size) => {
+      const json = {
+        sourceFile: infile,
+        destinationFile: outfile,
 
-      dimensions: size,
-      finalDimensions: size,
+        dimensions: size,
+        finalDimensions: size,
 
-      instructions: {},
-    };
+        instructions: {},
+      };
 
-    const instructions = markup
-      .trim()
-      .split(";")
-      .filter((x) => x);
+      const instructions = markup
+        .trim()
+        .split(";")
+        .filter((x) => x);
 
-    instructions.forEach((instruction) => {
-      const result = parseInstruction(instruction);
-      if (result.block === "crop") {
-        json["instructions"]["crop"] = result.instruction;
-        json["finalDimensions"] = result.instruction["size"];
-      }
-      if (result.block === "draw") {
-        if (!json["instructions"]["draw"]) {
-          json["instructions"]["draw"] = [];
+      instructions.forEach((instruction) => {
+        const result = parseInstruction(instruction);
+        if (result.block === "crop") {
+          json["instructions"]["crop"] = result.instruction;
+          json["finalDimensions"] = result.instruction["size"];
         }
-        const drawCommand = { [result.id]: result.instruction };
-        json["instructions"]["draw"].push(drawCommand);
+        if (result.block === "draw") {
+          if (!json["instructions"]["draw"]) {
+            json["instructions"]["draw"] = [];
+          }
+          const drawCommand = { [result.id]: result.instruction };
+          json["instructions"]["draw"].push(drawCommand);
+        }
+      });
+
+      if (stroke != null) {
+        json.instructions.strokeWidth = stroke;
       }
+
+      return json;
     });
-
-    if (stroke != null) {
-      json.instructions.strokeWidth = stroke;
-    }
-
-    return json;
-  });
 }
 
 function parseInstruction(instruction) {

--- a/src/new_markup_to_json.js
+++ b/src/new_markup_to_json.js
@@ -62,8 +62,10 @@ function convertMarkupToJSON(markup, infile, outfile, stroke) {
 
       json["instructions"] = {};
 
-      const nonEmpty = (instruction) => instruction != "";
-      var instructions = markup.split(";").filter(nonEmpty);
+      var instructions = markup
+        .trim()
+        .split(";")
+        .filter((x) => x);
 
       instructions.forEach((instruction) => {
         JSONFromMarkup(instruction, json);

--- a/test/000066.json
+++ b/test/000066.json
@@ -1,0 +1,49 @@
+{
+  "dimensions": { "width": 1200, "height": 900 },
+  "finalDimensions": { "width": 800, "height": 600 },
+  "instructions": {
+    "crop": {
+      "from": { "x": 399, "y": 300 },
+      "size": { "width": 800, "height": 600 }
+    },
+    "draw": [
+      {
+        "circle": {
+          "from": { "x": 882, "y": 474 },
+          "radius": 58,
+          "color": "orange"
+        }
+      },
+      {
+        "rectangle": {
+          "from": { "x": 494, "y": 368 },
+          "size": { "width": 101, "height": 161 },
+          "color": "violet"
+        }
+      },
+      {
+        "rectangle": {
+          "from": { "x": 694, "y": 360 },
+          "size": { "width": 247, "height": 172 },
+          "color": "blue"
+        }
+      },
+      {
+        "circle": {
+          "from": { "x": 656, "y": 447 },
+          "radius": 42,
+          "color": "green"
+        }
+      },
+      {
+        "circle": {
+          "from": { "x": 1131, "y": 810 },
+          "radius": 180,
+          "color": "red"
+        }
+      }
+    ]
+  },
+  "sourceFile": "./test/000066.source.jpg",
+  "destinationFile": "./literally.anywhere"
+}

--- a/test/00CC00.json
+++ b/test/00CC00.json
@@ -1,0 +1,42 @@
+{
+  "dimensions": { "width": 1200, "height": 900 },
+  "finalDimensions": { "width": 800, "height": 600 },
+  "instructions": {
+    "crop": {
+      "from": { "x": 399, "y": 0 },
+      "size": { "width": 800, "height": 600 }
+    },
+    "draw": [
+      {
+        "circle": {
+          "from": { "x": 944, "y": 406 },
+          "radius": 85,
+          "color": "red"
+        }
+      },
+      {
+        "rectangle": {
+          "from": { "x": 518, "y": 264 },
+          "size": { "width": 32, "height": 226 },
+          "color": "blue"
+        }
+      },
+      {
+        "rectangle": {
+          "from": { "x": 684, "y": 112 },
+          "size": { "width": 362, "height": 32 },
+          "color": "orange"
+        }
+      },
+      {
+        "circle": {
+          "from": { "x": 677, "y": 443 },
+          "radius": 11,
+          "color": "orange"
+        }
+      }
+    ]
+  },
+  "sourceFile": "./test/00CC00.source.jpg",
+  "destinationFile": "./literally.anywhere"
+}

--- a/test/66CCFF.json
+++ b/test/66CCFF.json
@@ -1,0 +1,35 @@
+{
+  "dimensions": { "width": 1200, "height": 900 },
+  "finalDimensions": { "width": 100, "height": 100 },
+  "instructions": {
+    "crop": {
+      "from": { "x": 100, "y": 100 },
+      "size": { "width": 100, "height": 100 }
+    },
+    "draw": [
+      {
+        "circle": {
+          "from": { "x": 150, "y": 150 },
+          "radius": 30,
+          "color": "yellow"
+        }
+      },
+      {
+        "rectangle": {
+          "from": { "x": 105, "y": 105 },
+          "size": { "width": 90, "height": 90 },
+          "color": "red"
+        }
+      },
+      {
+        "rectangle": {
+          "from": { "x": 115, "y": 115 },
+          "size": { "width": 70, "height": 70 },
+          "color": "orange"
+        }
+      }
+    ]
+  },
+  "sourceFile": "./test/66CCFF.source.jpg",
+  "destinationFile": "./literally.anywhere"
+}

--- a/test/9900CC.json
+++ b/test/9900CC.json
@@ -1,0 +1,42 @@
+{
+  "dimensions": { "width": 1200, "height": 900 },
+  "finalDimensions": { "width": 1200, "height": 900 },
+  "instructions": {
+    "crop": {
+      "from": { "x": 0, "y": 0 },
+      "size": { "width": 1200, "height": 900 }
+    },
+    "draw": [
+      {
+        "circle": {
+          "from": { "x": 400, "y": 424 },
+          "radius": 53,
+          "color": "black"
+        }
+      },
+      {
+        "circle": {
+          "from": { "x": 288, "y": 422 },
+          "radius": 24,
+          "color": "red"
+        }
+      },
+      {
+        "rectangle": {
+          "from": { "x": 465, "y": 372 },
+          "size": { "width": 93, "height": 153 },
+          "color": "yellow"
+        }
+      },
+      {
+        "rectangle": {
+          "from": { "x": 829, "y": 370 },
+          "size": { "width": 131, "height": 151 },
+          "color": "green"
+        }
+      }
+    ]
+  },
+  "sourceFile": "./test/9900CC.source.jpg",
+  "destinationFile": "./literally.anywhere"
+}

--- a/test/993333.json
+++ b/test/993333.json
@@ -1,0 +1,42 @@
+{
+  "dimensions": { "width": 1200, "height": 900 },
+  "finalDimensions": { "width": 1032, "height": 774 },
+  "instructions": {
+    "crop": {
+      "from": { "x": 168, "y": 71 },
+      "size": { "width": 1032, "height": 774 }
+    },
+    "draw": [
+      {
+        "circle": {
+          "from": { "x": 548, "y": 671 },
+          "radius": 21,
+          "color": "yellow"
+        }
+      },
+      {
+        "rectangle": {
+          "from": { "x": 287, "y": 484 },
+          "size": { "width": 28, "height": 28 },
+          "color": "blue"
+        }
+      },
+      {
+        "circle": {
+          "from": { "x": 980, "y": 467 },
+          "radius": 113,
+          "color": "red"
+        }
+      },
+      {
+        "rectangle": {
+          "from": { "x": 196, "y": 200 },
+          "size": { "width": 404, "height": 28 },
+          "color": "black"
+        }
+      }
+    ]
+  },
+  "sourceFile": "./test/993333.source.jpg",
+  "destinationFile": "./literally.anywhere"
+}

--- a/test/lines.json
+++ b/test/lines.json
@@ -1,0 +1,192 @@
+{
+  "dimensions": { "width": 1200, "height": 900 },
+  "finalDimensions": { "width": 1200, "height": 900 },
+  "instructions": {
+    "draw": [
+      {
+        "circle": {
+          "from": { "x": 77, "y": 207 },
+          "radius": 20,
+          "color": "red"
+        }
+      },
+      {
+        "circle": {
+          "from": { "x": 89, "y": 612 },
+          "radius": 20,
+          "color": "red"
+        }
+      },
+      {
+        "circle": {
+          "from": { "x": 909, "y": 201 },
+          "radius": 20,
+          "color": "orange"
+        }
+      },
+      {
+        "circle": {
+          "from": { "x": 549, "y": 197 },
+          "radius": 20,
+          "color": "orange"
+        }
+      },
+      {
+        "arrow": {
+          "from": { "x": 201, "y": 192 },
+          "to": { "x": 523, "y": 440 },
+          "color": "red"
+        }
+      },
+      {
+        "arrow": {
+          "from": { "x": 331, "y": 542 },
+          "to": { "x": 373, "y": 580 },
+          "color": "red"
+        }
+      },
+      {
+        "arrow": {
+          "from": { "x": 300, "y": 353 },
+          "to": { "x": 470, "y": 490 },
+          "color": "red"
+        }
+      },
+      {
+        "arrow": {
+          "from": { "x": 341, "y": 475 },
+          "to": { "x": 416, "y": 538 },
+          "color": "red"
+        }
+      },
+      {
+        "arrow": {
+          "from": { "x": 302, "y": 582 },
+          "to": { "x": 334, "y": 608 },
+          "color": "red"
+        }
+      },
+      {
+        "gap": {
+          "from": { "x": 305, "y": 84 },
+          "to": { "x": 973, "y": 84 },
+          "color": "red"
+        }
+      },
+      {
+        "gap": {
+          "from": { "x": 483, "y": 181 },
+          "to": { "x": 973, "y": 181 },
+          "color": "red"
+        }
+      },
+      {
+        "gap": {
+          "from": { "x": 621, "y": 296 },
+          "to": { "x": 967, "y": 296 },
+          "color": "red"
+        }
+      },
+      {
+        "gap": {
+          "from": { "x": 734, "y": 391 },
+          "to": { "x": 966, "y": 391 },
+          "color": "red"
+        }
+      },
+      {
+        "gap": {
+          "from": { "x": 842, "y": 482 },
+          "to": { "x": 967, "y": 482 },
+          "color": "red"
+        }
+      },
+      {
+        "gap": {
+          "from": { "x": 899, "y": 554 },
+          "to": { "x": 967, "y": 554 },
+          "color": "red"
+        }
+      },
+      {
+        "gap": {
+          "from": { "x": 935, "y": 638 },
+          "to": { "x": 966, "y": 638 },
+          "color": "red"
+        }
+      },
+      {
+        "line": {
+          "from": { "x": 100, "y": 100 },
+          "to": { "x": 200, "y": 200 },
+          "color": "red"
+        }
+      },
+      {
+        "line": {
+          "from": { "x": 300, "y": 200 },
+          "to": { "x": 200, "y": 100 },
+          "color": "yellow"
+        }
+      },
+      {
+        "line": {
+          "from": { "x": 350, "y": 100 },
+          "to": { "x": 350, "y": 200 },
+          "color": "black"
+        }
+      },
+      {
+        "line": {
+          "from": { "x": 400, "y": 100 },
+          "to": { "x": 500, "y": 100 },
+          "color": "orange"
+        }
+      },
+      {
+        "line": {
+          "from": { "x": 400, "y": 200 },
+          "to": { "x": 500, "y": 200 },
+          "color": "orange"
+        }
+      },
+      {
+        "line": {
+          "from": { "x": 400, "y": 300 },
+          "to": { "x": 500, "y": 300 },
+          "color": "orange"
+        }
+      },
+      {
+        "line": {
+          "from": { "x": 100, "y": 300 },
+          "to": { "x": 100, "y": 400 },
+          "color": "orange"
+        }
+      },
+      {
+        "line": {
+          "from": { "x": 100, "y": 300 },
+          "to": { "x": 100, "y": 400 },
+          "color": "black"
+        }
+      },
+      {
+        "line": {
+          "from": { "x": 200, "y": 300 },
+          "to": { "x": 200, "y": 400 },
+          "color": "black"
+        }
+      },
+      {
+        "line": {
+          "from": { "x": 200, "y": 300 },
+          "to": { "x": 200, "y": 400 },
+          "color": "black"
+        }
+      }
+    ]
+  },
+  "sourceFile": "./test/lines.source.jpg",
+  "destinationFile": "./literally.anywhere"
+}

--- a/test/simple-lines.json
+++ b/test/simple-lines.json
@@ -1,0 +1,42 @@
+{
+  "dimensions": { "width": 1200, "height": 900 },
+  "finalDimensions": { "width": 1024, "height": 768 },
+  "instructions": {
+    "crop": {
+      "from": { "x": 20, "y": 40 },
+      "size": { "width": 1024, "height": 768 }
+    },
+    "draw": [
+      {
+        "line": {
+          "from": { "x": 300, "y": 200 },
+          "to": { "x": 200, "y": 100 },
+          "color": "yellow"
+        }
+      },
+      {
+        "line": {
+          "from": { "x": 350, "y": 100 },
+          "to": { "x": 350, "y": 200 },
+          "color": "black"
+        }
+      },
+      {
+        "arrow": {
+          "from": { "x": 201, "y": 192 },
+          "to": { "x": 523, "y": 440 },
+          "color": "red"
+        }
+      },
+      {
+        "gap": {
+          "from": { "x": 305, "y": 84 },
+          "to": { "x": 973, "y": 84 },
+          "color": "red"
+        }
+      }
+    ]
+  },
+  "sourceFile": "./test/simple-lines.source.jpg",
+  "destinationFile": "./literally.anywhere"
+}


### PR DESCRIPTION
Talking with @sctice-ifixit and @andyg0808 about this, they were convinced that we could parse markup strings more easily with regex. They were right! Andrew took five minutes and wrote a quick and dirty parser implementation that works for us:
https://stackblitz.com/edit/js-5hvs6f?file=index.js

Without too much work, we can turn this into a simpler markup parser implementation, with much reduced mutation. Further, this implementation is potentially faster, though performance is not a major concern.
The first pass with cleanup/comments can be found here for posterity: https://github.com/iFixit/node-markup/pull/64
There were some rebase/conflict/base-branch shenanigans that made maintaining that specific branch difficult.

As a nice improvement, and to robustly test this new parser, we're now hard-coding the expected JSON output for each test case, and test parsing all of our test cases markup. This extends to testing all cases on _both_ parser implementations.

Now, in the new implementation, we're isolating mutating the `json` object into `convertMarkupToJSON` method, where the obvious concern is crafting the `json` object.

Lastly, note that we're adding and testing this new implementation, but not cutting over to it just yet. 

### CR note
This diff is going to look crazy until we've merged the two upstream branches.

CC @andyg0808 