### PR TITLE
Easy complexity cleanup

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -95,7 +95,9 @@ function ImageMarkupBuilder(fabricCanvas) {
       applyMarkup(callback);
     } else {
       finalWidth = innerJSON.finalDimensions.width;
-      if (isNode) {
+      if (!isNode) {
+        throw new Error("Source files not supported on frontend");
+      }
         fabricCanvas.setBackgroundColor("#FFFFFF");
         var dimensions = innerJSON.dimensions;
         var img = {
@@ -120,9 +122,6 @@ function ImageMarkupBuilder(fabricCanvas) {
           fabricCanvas.add(fimg.set("top", top).set("left", left));
           applyMarkup(callback);
         });
-      } else {
-        throw new Error("Source files not supported on frontend");
-      }
     }
   }
 

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -96,35 +96,35 @@ function ImageMarkupBuilder(fabricCanvas) {
       return;
     }
 
-      if (!isNode) {
-        throw new Error("Source files not supported on frontend");
+    if (!isNode) {
+      throw new Error("Source files not supported on frontend");
+    }
+
+    finalWidth = innerJSON.finalDimensions.width;
+    fabricCanvas.setBackgroundColor("#FFFFFF");
+    var dimensions = innerJSON.dimensions;
+    var img = {
+      width: dimensions.width,
+      height: dimensions.height,
+      originX: "left",
+      originY: "top",
+      src: "file://" + path.resolve(innerJSON.sourceFile),
+    };
+
+    Fabric.Image.fromObject(img, function (fimg, err) {
+      if (!fimg || err) throw err;
+      var top = -imageOffset.y;
+      if (top % 1 != 0) {
+        top -= 0.5;
+      }
+      var left = -imageOffset.x;
+      if (left % 1 != 0) {
+        left -= 0.5;
       }
 
-      finalWidth = innerJSON.finalDimensions.width;
-        fabricCanvas.setBackgroundColor("#FFFFFF");
-        var dimensions = innerJSON.dimensions;
-        var img = {
-          width: dimensions.width,
-          height: dimensions.height,
-          originX: "left",
-          originY: "top",
-          src: "file://" + path.resolve(innerJSON.sourceFile),
-        };
-
-        Fabric.Image.fromObject(img, function (fimg, err) {
-          if (!fimg || err) throw err;
-          var top = -imageOffset.y;
-          if (top % 1 != 0) {
-            top -= 0.5;
-          }
-          var left = -imageOffset.x;
-          if (left % 1 != 0) {
-            left -= 0.5;
-          }
-
-          fabricCanvas.add(fimg.set("top", top).set("left", left));
-          applyMarkup(callback);
-        });
+      fabricCanvas.add(fimg.set("top", top).set("left", left));
+      applyMarkup(callback);
+    });
   }
 
   /**

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -93,11 +93,14 @@ function ImageMarkupBuilder(fabricCanvas) {
 
       //Apply markup to blank canvas
       applyMarkup(callback);
-    } else {
-      finalWidth = innerJSON.finalDimensions.width;
+      return;
+    }
+
       if (!isNode) {
         throw new Error("Source files not supported on frontend");
       }
+
+      finalWidth = innerJSON.finalDimensions.width;
         fabricCanvas.setBackgroundColor("#FFFFFF");
         var dimensions = innerJSON.dimensions;
         var img = {
@@ -122,7 +125,6 @@ function ImageMarkupBuilder(fabricCanvas) {
           fabricCanvas.add(fimg.set("top", top).set("left", left));
           applyMarkup(callback);
         });
-    }
   }
 
   /**


### PR DESCRIPTION
The use of `else`, and a large `if (isNode)` block here make for a unnecessary double indent on around 30 lines of `applyBackground`. We can early return instead to reduce complexity.

qa_req 0 (no behavior changes)

CC @iFixit/devops