### PR TITLE
Bugfix: StrokeWidth

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -237,7 +237,6 @@ function ImageMarkupBuilder(fabricCanvas) {
       top: shape.from.y - imageOffset.y,
       width: shape.size.width,
       height: shape.size.height,
-      borderWidth: shape.stroke,
       stroke: colorValues[shape.color],
       strokeWidth: shape.strokeWidth,
       color: shape.color,
@@ -266,7 +265,6 @@ function ImageMarkupBuilder(fabricCanvas) {
     shape.strokeWidth = getStrokeWidth(finalWidth);
 
     var line = {
-      borderWidth: shape.stroke,
       stroke: colorValues[shape.color],
       strokeWidth: shape.strokeWidth,
       color: shape.color,
@@ -300,7 +298,6 @@ function ImageMarkupBuilder(fabricCanvas) {
       left: shape.from.x - imageOffset.x,
       top: shape.from.y - imageOffset.y,
       radius: shape.radius,
-      borderWidth: shape.stroke,
       stroke: colorValues[shape.color],
       strokeWidth: shape.strokeWidth,
       color: shape.color,

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -239,6 +239,7 @@ function ImageMarkupBuilder(fabricCanvas) {
       height: shape.size.height,
       borderWidth: shape.stroke,
       stroke: colorValues[shape.color],
+      strokeWidth: shape.strokeWidth,
       color: shape.color,
     };
 
@@ -267,6 +268,7 @@ function ImageMarkupBuilder(fabricCanvas) {
     var line = {
       borderWidth: shape.stroke,
       stroke: colorValues[shape.color],
+      strokeWidth: shape.strokeWidth,
       color: shape.color,
     };
 
@@ -300,6 +302,7 @@ function ImageMarkupBuilder(fabricCanvas) {
       radius: shape.radius,
       borderWidth: shape.stroke,
       stroke: colorValues[shape.color],
+      strokeWidth: shape.strokeWidth,
       color: shape.color,
     };
     circle.left *= resizeRatio;

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -239,7 +239,6 @@ function ImageMarkupBuilder(fabricCanvas) {
       height: shape.size.height,
       stroke: colorValues[shape.color],
       strokeWidth: shape.strokeWidth,
-      color: shape.color,
     };
 
     //Fabric調整
@@ -267,7 +266,6 @@ function ImageMarkupBuilder(fabricCanvas) {
     var line = {
       stroke: colorValues[shape.color],
       strokeWidth: shape.strokeWidth,
-      color: shape.color,
     };
 
     var points = [
@@ -300,7 +298,6 @@ function ImageMarkupBuilder(fabricCanvas) {
       radius: shape.radius,
       stroke: colorValues[shape.color],
       strokeWidth: shape.strokeWidth,
-      color: shape.color,
     };
     circle.left *= resizeRatio;
     circle.top *= resizeRatio;

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -230,7 +230,7 @@ function ImageMarkupBuilder(fabricCanvas) {
   }
 
   function drawRectangle(shape) {
-    shape.stroke = getStrokeWidth(finalWidth);
+    shape.strokeWidth = getStrokeWidth(finalWidth);
 
     var rect = {
       left: shape.from.x - imageOffset.x,
@@ -262,7 +262,7 @@ function ImageMarkupBuilder(fabricCanvas) {
   }
 
   function drawLineBasedShape(klass, shape) {
-    shape.stroke = getStrokeWidth(finalWidth);
+    shape.strokeWidth = getStrokeWidth(finalWidth);
 
     var line = {
       borderWidth: shape.stroke,
@@ -292,7 +292,7 @@ function ImageMarkupBuilder(fabricCanvas) {
   }
 
   function drawCircle(shape) {
-    shape.stroke = getStrokeWidth(finalWidth);
+    shape.strokeWidth = getStrokeWidth(finalWidth);
 
     var circle = {
       left: shape.from.x - imageOffset.x,


### PR DESCRIPTION
Fix a Fabric.js interface mismatch on our latest version.

Specifically, it appears master is trying to pass `borderWidth` to Fabric objects for their strokeWidth. This does not draw  objects as expected. We see that 

Here's a montage of the test images from master:
![montage-master](https://user-images.githubusercontent.com/6876047/189737753-fa7e685d-cbcc-4807-8d68-2ecd8388a8fd.jpg)

:warning: Notes:
- The rectangle shape has been shifted slightly now. It appears the "corner" of the shape is now at the edge of the stroke, not centered in the corner as prior. This is difficult to describe, but it appears the position of the rectangle has changed to be about a half strokeWidth in the +X and +Y direction.
- The white shadow/border is not being drawn as expected. Perhaps the mixin is not getting called the way we expect.

With these light fixes applied, we're actually drawing the shapes we expect, pretty close to our test oracle images:
![montage-branch](https://user-images.githubusercontent.com/6876047/189738271-f9be79f7-fbb7-4bcc-93a1-4521359fd3ce.jpg)

qa_req 0 (another small step in the right direction here)

Ref: https://github.com/iFixit/ifixit/issues/43782

CC @iFixit/devops 
