### PR TITLE
Bugfix: `_renderStroke` fix custom stroke override method

### DIFF
--- a/mixins/highlighted_stroke.mixin.js
+++ b/mixins/highlighted_stroke.mixin.js
@@ -9,7 +9,7 @@ module.exports = {
    * Provide a custom stroke function that draws a fat white line THEN a
    * narrower colored line on top.
    */
-  _stroke: function (ctx) {
+  _renderStroke: function (ctx) {
     var myScale = this.scaleX;
     var outline = this._outlineWidth();
     function scale(x) {

--- a/shapes/arrow.js
+++ b/shapes/arrow.js
@@ -4,7 +4,7 @@ var Arrow = Fabric.util.createClass(require("./line").klass, {
   type: "arrow",
   shapeName: "arrow",
 
-  _stroke: function (ctx) {
+  _renderStroke: function (ctx) {
     var angle = this._getAngle();
     var rad = this._getLength();
     var canvasSize = this._canvasSize();
@@ -20,7 +20,7 @@ var Arrow = Fabric.util.createClass(require("./line").klass, {
     ctx.lineTo(0, 0);
     ctx.lineTo(x2, y2);
 
-    this.callSuper("_stroke", ctx);
+    this.callSuper("_renderStroke", ctx);
   },
 });
 

--- a/shapes/gap.js
+++ b/shapes/gap.js
@@ -6,7 +6,7 @@ var Gap = Fabric.util.createClass(require("./line").klass, {
   // Min and Max size to enforce (false == no enforcement)
   sizeLimits: [0.03, 0.95],
 
-  _stroke: function (ctx) {
+  _renderStroke: function (ctx) {
     var angle = this._getAngle();
     var canvasSize = this._canvasSize();
 
@@ -23,7 +23,7 @@ var Gap = Fabric.util.createClass(require("./line").klass, {
     ctx.moveTo(x, y);
     ctx.lineTo(x2, y2);
 
-    this.callSuper("_stroke", ctx);
+    this.callSuper("_renderStroke", ctx);
   },
 });
 


### PR DESCRIPTION
Peeking into the fabric source, it looks like the `_stroke` method we're overriding in the [`highlighted_stroke`](https://github.com/iFixit/node-markup/blob/master/mixins/highlighted_stroke.mixin.js) mixin has been renamed to `_renderStroke`. Making sure we override the correct method, we start seeing our customized stroke rendering.

Master:
![montage](https://user-images.githubusercontent.com/6876047/189766622-cee0e618-6552-442b-8f34-8fb38b14fef7.jpg)

:exclamation: Edit:
This commit: https://github.com/iFixit/node-markup/pull/73/commits/ddc01aff294d259085d3c2cc1fd0ed8975999b36
which is practically the same fix, for the gap and arrow shapes, fixes the "line based shape" extra endings as well.
See: https://github.com/iFixit/node-markup/pull/73#issuecomment-1244669528

Updated montage :framed_picture: :
![image](https://user-images.githubusercontent.com/6876047/189772065-7aa91936-e26e-4278-adbf-af6adc924d7b.png)


This branch:
![montage-branch](https://user-images.githubusercontent.com/6876047/189766650-16f88d18-2d14-4929-b779-103515c42c91.jpg)

### Background
Our version of Fabric (v1.6) calls into the `_stroke` method (if it exists) in `_renderStroke`:
https://github.com/fabricjs/fabric.js/blob/8a845b93f858f54a5a425b7dd275a43ff5ecf303/src/shapes/object.class.js#L1198
But the latest does not:
https://github.com/fabricjs/fabric.js/blob/9c683624e44335a13831387997add866799b1a92/src/shapes/object.class.ts#L1616

qa_req 0 (unused, incremental improvement)

Ref: https://github.com/iFixit/ifixit/issues/43782

CC @iFixit/devops 