### PR TITLE
Bugfix: Fix strokeline props

### DIFF
--- a/mixins/highlighted_stroke.mixin.js
+++ b/mixins/highlighted_stroke.mixin.js
@@ -4,6 +4,8 @@ module.exports = {
   // in percentage of borderWidth
   outlineWidth: 0.2,
   outlineStyle: "#FFF",
+  strokeLineCap: "round",
+  strokeLineJoin: "round",
 
   /**
    * Provide a custom stroke function that draws a fat white line THEN a
@@ -15,6 +17,10 @@ module.exports = {
     function scale(x) {
       return Math.round(x) / myScale;
     }
+
+    ctx.lineCap = this.strokeLineCap;
+    ctx.lineJoin = this.strokeLineJoin;
+
     ctx.lineWidth = scale(this.borderWidth + outline);
     ctx.strokeStyle = this.outlineStyle;
     ctx.stroke();

--- a/shapes/line.js
+++ b/shapes/line.js
@@ -6,8 +6,6 @@ var Line = Fabric.util.createClass(Fabric.Line, {
   lockRotation: true,
   transparentCorners: false,
   hasRotatingPoint: false,
-  strokeLineCap: "round",
-  strokeLineJoin: "round",
   fill: "transparent",
 
   // New fields.

--- a/shapes/rectangle.js
+++ b/shapes/rectangle.js
@@ -12,7 +12,6 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
   hasRotatingPoint: false,
   hasBorders: false,
   fill: "transparent",
-  strokeLineJoin: "round",
 
   // New fields.
   shapeName: "rectangle",


### PR DESCRIPTION
The `strokeLineCap` and `strokeLineJoin` properties we are using for our custom stroke implementation do not match the Canvas API properties for the same.
Ref: (Fabric): http://fabricjs.com/docs/fabric.Line.html#strokeLineCap
This seems to match the SVG name for that property:
Ref: (MDN SVGs): https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap
But not the Canvas API for the same:
Ref: (MDN CanvasRC2D): https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap

This repairs the nice rounded edges (for lines, and the drop highlight) for our lines, caps, and rectangles.

### Examples
<table>
<thead>
<tr>
<th>master</th>
<th>branch</th>
</tr>

<tr>
<td>

![66CCFF node test](https://user-images.githubusercontent.com/6876047/189779228-fea70c66-6bf6-4df5-903d-5cdbefce0587.jpg)


</td>
<td>

![66CCFF node test](https://user-images.githubusercontent.com/6876047/189778915-70a39c67-bb70-4714-a3f8-f8f0bdecc44b.jpg)

</td>
</tr>

<tr>
<td>

![lines node test](https://user-images.githubusercontent.com/6876047/189779247-bc8c7b1d-166f-4cca-90d8-760484b70e33.jpg)
</td>
<td>

![lines node test](https://user-images.githubusercontent.com/6876047/189779062-0f07fd5b-14c1-436b-8253-62e21a494e52.jpg)

</td>
</tr>

<tr>
<td>

![simple-lines node test](https://user-images.githubusercontent.com/6876047/189779272-0bde6416-8707-44f3-922a-8024fd23a078.jpg)

</td>
<td>

![simple-lines node test](https://user-images.githubusercontent.com/6876047/189779123-8a0cdac0-027f-424c-a812-72d4530951c6.jpg)

</td>
</tr>


</table>

Ref: https://github.com/iFixit/ifixit/issues/43782

CC @iFixit/devops 