### PR TITLE
Bugfix: put back borderWidth

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -239,6 +239,7 @@ function ImageMarkupBuilder(fabricCanvas) {
       height: shape.size.height,
       stroke: colorValues[shape.color],
       strokeWidth: shape.strokeWidth,
+      borderWidth: shape.strokeWidth,
     };
 
     //Fabric調整
@@ -266,6 +267,7 @@ function ImageMarkupBuilder(fabricCanvas) {
     var line = {
       stroke: colorValues[shape.color],
       strokeWidth: shape.strokeWidth,
+      borderWidth: shape.strokeWidth,
     };
 
     var points = [
@@ -298,6 +300,7 @@ function ImageMarkupBuilder(fabricCanvas) {
       radius: shape.radius,
       stroke: colorValues[shape.color],
       strokeWidth: shape.strokeWidth,
+      borderWidth: shape.strokeWidth,
     };
     circle.left *= resizeRatio;
     circle.top *= resizeRatio;


### PR DESCRIPTION
In this commit, i erroneously dropped the `borderWidth` property. https://github.com/iFixit/node-markup/pull/72/commits/3ad42ee7b8398168e0c6399c87a46289e17f3555

At the time, using this property was changing object positioning in difficult to explain ways. Presumably fixing our render functions in #73 has corrected the positioning bug. Bring back this property, effectively the strokeWidth, brings the line widths on our test images into much better parity with the oracle images.

qa_req 0

Ref: https://github.com/iFixit/ifixit/issues/43782

CC @iFixit/devops 