### PR TITLE
Misc Image writing fixes

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -208,7 +208,7 @@ function ImageMarkupBuilder(fabricCanvas) {
     fabricCanvas.renderAll();
     var outstream = require("fs").createWriteStream(innerJSON.destinationFile),
       stream = fabricCanvas.createJPEGStream({
-        quality: 93,
+        quality: 0.93,
         progressive: true,
       });
 

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -459,7 +459,7 @@ function ImageMarkupBuilder(fabricCanvas) {
     processJSON: function processJSON(json, callback) {
       //Make sure not to render every addition on server end
       fabricCanvas.renderOnAddition = !isNode;
-      fabricCanvas.uniScaleTransform = true;
+      fabricCanvas.uniformScaling = true;
 
       cleanJSON(json);
 

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -206,18 +206,20 @@ function ImageMarkupBuilder(fabricCanvas) {
    */
   function writeCanvas(callback) {
     fabricCanvas.renderAll();
-    var outstream = require("fs").createWriteStream(innerJSON.destinationFile),
-      stream = fabricCanvas.createJPEGStream({
-        quality: 0.93,
-        progressive: true,
-      });
+    const outstream = require("fs").createWriteStream(
+      innerJSON.destinationFile
+    );
 
-    stream.on("data", function (chunk) {
-      outstream.write(chunk);
+    const stream = fabricCanvas.createJPEGStream({
+      quality: 0.93,
+      progressive: true,
     });
+
     stream.on("end", function () {
       callback(fabricCanvas);
     });
+
+    stream.pipe(outstream);
   }
 
   /**

--- a/shapes/circle.js
+++ b/shapes/circle.js
@@ -9,7 +9,6 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
   originY: "center",
   lockRotation: true,
   transparentCorners: false,
-  lockUniScaling: true,
   fill: "transparent",
   centeredScaling: true,
 

--- a/shapes/circle.js
+++ b/shapes/circle.js
@@ -11,6 +11,7 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
   transparentCorners: false,
   fill: "transparent",
   centeredScaling: true,
+  objectCaching: false,
 
   // New fields.
   shapeName: "circle",

--- a/shapes/circle.js
+++ b/shapes/circle.js
@@ -9,7 +9,6 @@ var Circle = Fabric.util.createClass(Fabric.Circle, {
   originY: "center",
   lockRotation: true,
   transparentCorners: false,
-  hasRotatingPoint: false,
   lockUniScaling: true,
   fill: "transparent",
   centeredScaling: true,

--- a/shapes/line.js
+++ b/shapes/line.js
@@ -6,6 +6,7 @@ var Line = Fabric.util.createClass(Fabric.Line, {
   lockRotation: true,
   transparentCorners: false,
   fill: "transparent",
+  objectCaching: false,
 
   // New fields.
   shapeName: "line",

--- a/shapes/line.js
+++ b/shapes/line.js
@@ -10,6 +10,15 @@ var Line = Fabric.util.createClass(Fabric.Line, {
   // New fields.
   shapeName: "line",
   sizeLimits: [0.04, 0.4],
+
+  render: function (ctx) {
+    const offFactor = this.borderWidth / 2.0;
+
+    this.top -= offFactor;
+    this.left -= offFactor;
+
+    this.callSuper("render", ctx);
+  },
 });
 
 var proto = Line.prototype;

--- a/shapes/line.js
+++ b/shapes/line.js
@@ -5,7 +5,6 @@ var Line = Fabric.util.createClass(Fabric.Line, {
   type: "line",
   lockRotation: true,
   transparentCorners: false,
-  hasRotatingPoint: false,
   fill: "transparent",
 
   // New fields.

--- a/shapes/rectangle.js
+++ b/shapes/rectangle.js
@@ -79,6 +79,11 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
       this.height += partialY * 2;
     }
 
+    const offFactor = this.borderWidth / 2.0;
+
+    this.top -= offFactor;
+    this.left -= offFactor;
+
     callback.call(this);
 
     this.width = old.w;

--- a/shapes/rectangle.js
+++ b/shapes/rectangle.js
@@ -11,6 +11,7 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
   transparentCorners: true,
   hasBorders: false,
   fill: "transparent",
+  objectCaching: false,
 
   // New fields.
   shapeName: "rectangle",

--- a/shapes/rectangle.js
+++ b/shapes/rectangle.js
@@ -9,7 +9,6 @@ var Rectangle = Fabric.util.createClass(Fabric.Rect, {
   originY: "top",
   lockRotation: true,
   transparentCorners: true,
-  hasRotatingPoint: false,
   hasBorders: false,
   fill: "transparent",
 


### PR DESCRIPTION
In trying to get our generated images to match the test oracles, we've found a few assorted fixes and touchups.

An otherwise difficult to account for position bug is fixed in: https://github.com/iFixit/node-markup/commit/3ffa73aa0dfe9e7ef0d305f2e4412e6fdb4c6156
I dont love that we need a mutation based bump like that, but that fix brings the line and rectangle position into near pixel-perfect parity with the test oracle images. At the least, it highlights the bug, until we can better maintain the positioning logic.

Also, on testing using this new latest version we found that the object/canvas caching was breaking, in surprising ways, in-browser. Disabling that caching (temporarily?) gets the UI working reasonably well.

See individual commit messages for more details.

qa_req 0 (tests are passing _better_ now)

Ref: https://github.com/iFixit/ifixit/issues/43782

CC @iFixit/devops 