### PR TITLE
Export Fabric

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -2,11 +2,12 @@ const { isNode, cleanJSON } = require("./src/utils");
 const Shapes = require("./shapes");
 const path = require("path");
 
+const Fabric = require("fabric").fabric;
+
 /**
  * Expects a Fabric.js Canvas
  */
 function ImageMarkupBuilder(fabricCanvas) {
-  var Fabric = require("fabric").fabric;
 
   var colorValues = {
     red: "#C1280B",

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -9,7 +9,6 @@ module.exports.Fabric = Fabric;
  * Expects a Fabric.js Canvas
  */
 function ImageMarkupBuilder(fabricCanvas) {
-
   var colorValues = {
     red: "#C1280B",
     orange: "#FF9024",

--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -3,6 +3,7 @@ const Shapes = require("./shapes");
 const path = require("path");
 
 const Fabric = require("fabric").fabric;
+module.exports.Fabric = Fabric;
 
 /**
  * Expects a Fabric.js Canvas


### PR DESCRIPTION
We're using a custom build of Fabric.js internally. In order to facilitate dependency management, export our Fabric dependency from `Builder`. This lets us avoid manually managing this peer dependency.

We intend upstream to explicitly reuse this Fabric.js dependency:
https://github.com/iFixit/ifixit/blob/394eeb1c6164e88360827aa9bc3e6013f661e44d/carpenter-frontend/Shared/FrameModules/Image/image_markers_next.js#L258

Ref: https://github.com/iFixit/ifixit/issues/43782

CC @iFixit/devops 