### PR TITLE
Avoid node dependencies in Builder

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -1,6 +1,5 @@
 const { isNode, cleanJSON } = require("./src/utils");
 const Shapes = require("./shapes");
-const path = require("path");
 
 const Fabric = require("fabric").fabric;
 module.exports.Fabric = Fabric;
@@ -124,7 +123,7 @@ function ImageMarkupBuilder(fabricCanvas) {
       height: dimensions.height,
       originX: "left",
       originY: "top",
-      src: "file://" + path.resolve(innerJSON.sourceFile),
+      src: innerJSON.sourceFile,
     };
 
     Fabric.Image.fromObject(img, function (fimg, err) {

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -3,6 +3,8 @@ var convertMarkupToJSON = require("./src/markup_to_json");
 var ImageMarkupBuilder = require("./ImageMarkupBuilder").Builder;
 var Fabric = require("fabric").fabric;
 
+const path = require("path");
+
 const RequiredCommands =
   "Invalid usage: Please provide exactly one of the `markup` or the `json` commands";
 var yargs = require("yargs")
@@ -117,6 +119,10 @@ function shimForFlags(argv) {
 
 function processJSON(json) {
   cleanJSON(json);
+
+  if (json.sourceFile) {
+    json.sourceFile = `file://${path.resolve(json.sourceFile)}`;
+  }
 
   var finalSize = json["finalDimensions"];
   var canvas = new Fabric.StaticCanvas(null, {


### PR DESCRIPTION
Specifically, we want to import our Builder in the browser context. Currently, this fails hard and fast at our `require` of `path` in the Builder.

![image](https://user-images.githubusercontent.com/6876047/191130178-4ee954cf-1714-44ab-93ea-1012e492fcb3.png)

In this commit: https://github.com/iFixit/node-markup/commit/ee1c72a3c4b39fbad87d2bba88e51c3ddc4162d4 during the Fabric upgrade, we switched to passing a full `file://` URL in the options to `Fabric.Image.fromObject`. This was to handle a change to the Fabric internals where we now require an URL.

We can use `path.resolve` to build our `file://` URL, but `path` is a Node specific dependency, and breaks at webpack (can't resolve that module without a polyfill.)

We can avoid the trouble by pre-resolving this path/URL in the outer `ImageMarkupCall` wrapper. Since that file is the node-specific entrypoint, it is safe for us to require and use `path` here.

Further note that this code is already under a guard that ensures we _only_ use it from Node:
https://github.com/iFixit/node-markup/blob/32a5cd7810bd4021751df01282f5d53f1838d750/ImageMarkupBuilder.js#L114-L115

This keeps the node specific dependency inside the node entrypoint, and should avoid needing to polyfill `path` on the browser side.

Ref: https://github.com/iFixit/ifixit/issues/43782

CC @andyg0808 @iFixit/devops 
