### PR TITLE
Bump Fabric.js to include Animations module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test/*.test.jpg
 
 # Ignore vim swap files
 .*.sw?
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "canvas": "2.9.3",
     "gm": "1.23.1",
-    "fabric": "https://github.com/iFixit/fabric.js.git#try-v521",
+    "fabric": "https://github.com/iFixit/fabric.js.git#try-v521-with-anim",
     "yargs": "^13.3.2"
   },
   "version": "0.0.2",


### PR DESCRIPTION
Integrates a branch upstream on Fabric.js:
https://github.com/iFixit/fabric.js/compare/try-v521...iFixit:fabric.js:try-v521-with-anim

:warning: note the diff shows only the changes we are integrating here and now. Specifically:
- Add the `animation` module to our custom build
- regen `dist`

In the main app, we're seeing several different actions and codepaths that trigger internal Fabric usage of `farbic.util.requestAnimationFrame`. Without this animation module, we see hard crashes of the in-browser editor. I think for the short term, it will be better to tolerate the extra Fabric module. Eventually we may work to remove the dependency on `requestAnimationFrame`, but for now, "working at all" is better than nothing.

Ref: https://github.com/iFixit/ifixit/issues/43782

CC @iFixit/devops 